### PR TITLE
Mark validators as internal to hide it from tsd

### DIFF
--- a/source/lib/predicates/predicate.ts
+++ b/source/lib/predicates/predicate.ts
@@ -9,6 +9,8 @@ export interface Context {
 	validators: Validator<any>[];
 }
 
+export const validatorSymbol = Symbol('validators');
+
 export class Predicate<T = any> {
 	constructor(
 		type: string,
@@ -20,7 +22,7 @@ export class Predicate<T = any> {
 		});
 	}
 
-	get validators() {
+	get [validatorSymbol]() {
 		return this.context.validators;
 	}
 

--- a/source/ow.ts
+++ b/source/ow.ts
@@ -1,6 +1,6 @@
 import * as is from '@sindresorhus/is';
 import { ArgumentError } from './lib/argument-error';
-import { Predicate } from './lib/predicates/predicate';
+import { Predicate, validatorSymbol } from './lib/predicates/predicate';
 import { StringPredicate } from './lib/predicates/string';
 
 export interface Ow {
@@ -12,7 +12,7 @@ export interface Ow {
 }
 
 export const ow: Ow = (value: any, predicate: Predicate) => {
-	for (const { validator, message } of predicate.validators) {
+	for (const { validator, message } of predicate[validatorSymbol]) {
 		if (!validator(value)) {
 			// TODO: Modify the stack output to show the original `ow()` call instead of this `throw` statement
 			throw new ArgumentError(message(value), ow);


### PR DESCRIPTION
Currently, this looks like the best option to mark `_validators` as internal. Let me know if you want to add another comment.

https://twitter.com/SamVerschueren/status/918902592675241984