### PR TITLE
Fix support for Node.js 4

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
 	"compilerOptions": {
-		"target": "es2016",
+		"target": "es5",
 		"module": "commonjs",
 		"declaration": false,
 		"removeComments": false,
@@ -12,7 +12,10 @@
 		"noFallthroughCasesInSwitch": true,
 		"allowSyntheticDefaultImports": true,
 		"strictNullChecks": true,
-		"outDir": "dist"
+		"outDir": "dist",
+		"lib": [
+			"es2015"
+		]
 	},
 	"exclude": [
 		"node_modules",


### PR DESCRIPTION
We have to target ES5 because destructuring and default function arguments do not work in Node.js 4.

When this is merged, I will take a look at how we can fix the proxy integration in #12 . Otherwise I will revert to what we had before.