### PR TITLE
Simplify module.exports webpack config

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
 		"@sindresorhus/is": "^0.6.0",
 		"@types/highlight.js": "^9.12.2",
 		"@types/node": "^8.0.31",
-		"add-asset-webpack-plugin": "^0.1.0",
+		"add-module-exports-webpack-plugin": "^0.1.0",
 		"ava": "*",
 		"awesome-typescript-loader": "^3.2.3",
 		"codecov": "^3.0.0",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,7 +1,7 @@
 'use strict';
 const webpack = require('webpack');
 const license = require('license-webpack-plugin');
-const AddAssetPlugin = require('add-asset-webpack-plugin');
+const AddModuleExportsPlugin = require('add-module-exports-webpack-plugin');
 
 module.exports = {
 	entry: './source/index.ts',
@@ -9,7 +9,7 @@ module.exports = {
 	node: false,
 	devtool: 'source-map',
 	output: {
-		filename: 'dist/ow.js',
+		filename: 'dist/index.js',
 		libraryTarget: 'commonjs2'
 	},
 	resolve: {
@@ -17,11 +17,7 @@ module.exports = {
 	},
 	plugins: [
 		new webpack.optimize.ModuleConcatenationPlugin(),
-		new AddAssetPlugin('dist/index.js', `
-			'use strict';
-			module.exports = require('./ow').default;
-			module.exports.default = module.exports;
-		`),
+		new AddModuleExportsPlugin(),
 		new license.LicenseWebpackPlugin({
 			pattern: /.*/,
 			outputFilename: 'dist/licenses.txt'


### PR DESCRIPTION
I want the least amount of boilerplate in our webpack config.