### PR TITLE
Turn on `noImplicitAny` flag - fixes #3

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,9 @@
 	"devDependencies": {
 		"@sindresorhus/is": "^0.7.0",
 		"@types/highlight.js": "^9.12.2",
+		"@types/lodash.isequal": "^4.5.2",
 		"@types/node": "^8.0.31",
+		"@types/vali-date": "^1.0.0",
 		"add-module-exports-webpack-plugin": "^0.1.0",
 		"ava": "*",
 		"awesome-typescript-loader": "^3.2.3",

--- a/source/index.ts
+++ b/source/index.ts
@@ -1,5 +1,5 @@
 import {ArgumentError} from './lib/argument-error';
-import {Predicate, validatorSymbol} from './lib/predicates/predicate';
+import {Predicate, validatorSymbol, Validator} from './lib/predicates/predicate';
 import {StringPredicate} from './lib/predicates/string';
 import {NumberPredicate} from './lib/predicates/number';
 import {BooleanPredicate} from './lib/predicates/boolean';
@@ -155,7 +155,9 @@ export interface Ow {
 }
 
 const main = <T>(value: T, predicate: Predicate<T>) => {
-	for (const {validator, message} of predicate[validatorSymbol]) {
+	const validators: Validator<any>[] = (predicate as any)[validatorSymbol];
+
+	for (const {validator, message} of validators) {
 		const result = validator(value);
 
 		if (typeof result !== 'boolean' || !result) {

--- a/source/lib/operators/not.ts
+++ b/source/lib/operators/not.ts
@@ -14,7 +14,7 @@ export const not = <T extends Predicate>(predicate: T) => {
 		validator.message = (x: any) => `[NOT] ${message(x)}`;
 		validator.validator = (x: any) => !fn(x);
 
-		predicate[validatorSymbol].push(validator);
+		(predicate as any)[validatorSymbol].push(validator);
 
 		return predicate;
 	};

--- a/source/lib/predicates/array.ts
+++ b/source/lib/predicates/array.ts
@@ -1,4 +1,4 @@
-import * as isEqual from 'lodash.isequal';
+import isEqual = require('lodash.isequal');				// tslint:disable-line:no-require-imports
 import ow from '../..';
 import {Predicate, Context} from './predicate';
 

--- a/source/lib/predicates/map.ts
+++ b/source/lib/predicates/map.ts
@@ -1,4 +1,4 @@
-import * as isEqual from 'lodash.isequal';
+import isEqual = require('lodash.isequal');				// tslint:disable-line:no-require-imports
 import {Predicate, Context} from './predicate';
 import hasItems from '../utils/has-items';
 import ofType from '../utils/of-type';

--- a/source/lib/predicates/predicate.ts
+++ b/source/lib/predicates/predicate.ts
@@ -33,7 +33,7 @@ export class Predicate<T = any> {
 	) {
 		this.addValidator({
 			message: value => `Expected argument to be of type \`${type}\` but received type \`${is(value)}\``,
-			validator: value => is[type](value)
+			validator: value => (is as any)[type](value)
 		});
 	}
 

--- a/source/lib/predicates/set.ts
+++ b/source/lib/predicates/set.ts
@@ -1,4 +1,4 @@
-import * as isEqual from 'lodash.isequal';
+import isEqual = require('lodash.isequal');				// tslint:disable-line:no-require-imports
 import {Predicate, Context} from './predicate';
 import hasItems from '../utils/has-items';
 import ofType from '../utils/of-type';

--- a/source/test/undefined.ts
+++ b/source/test/undefined.ts
@@ -2,7 +2,7 @@ import test from 'ava';
 import m from '..';
 
 test('undefined', t => {
-	let x;						// tslint:disable-line:prefer-const
+	const x = undefined;
 	const y = 12;
 
 	t.notThrows(() => m(undefined, m.undefined));

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,7 +11,7 @@
 		"pretty": true,
 		"newLine": "lf",
 		"stripInternal": true,
-		"noImplicitAny": false,
+		"noImplicitAny": true,
 		"noImplicitReturns": true,
 		"noImplicitThis": true,
 		"noUnusedLocals": true,


### PR DESCRIPTION
Added my `vali-date` types to `DefinitelyTyped` so was finally able to do this :). Had to use the `import X = require('X');` syntax for lodash in order for it to work with the type definitions.