### PR TITLE
Add object.deepValuesOfType validator - fixes #51

### DIFF
--- a/source/lib/predicates/object.ts
+++ b/source/lib/predicates/object.ts
@@ -3,6 +3,7 @@ import isEqual = require('lodash.isequal'); // tslint:disable-line:no-require-im
 import {Predicate, Context} from './predicate';
 import hasItems from '../utils/has-items';
 import ofType from '../utils/of-type';
+import ofTypeDeep from '../utils/of-type-deep';
 
 export class ObjectPredicate extends Predicate<object> {
 	constructor(context?: Context) {
@@ -52,6 +53,18 @@ export class ObjectPredicate extends Predicate<object> {
 
 				return ofType(values, predicate);
 			}
+		});
+	}
+
+	/**
+	 * Test all the values in the object deeply to match the provided predicate.
+	 *
+	 * @param predicate The predicate that should be applied against every value in the object.
+	 */
+	deepValuesOfType<T>(predicate: Predicate<T>) {
+		return this.addValidator({
+			message: (_, error) => error,
+			validator: (object: any) => ofTypeDeep(object, predicate)
 		});
 	}
 

--- a/source/lib/utils/of-type-deep.ts
+++ b/source/lib/utils/of-type-deep.ts
@@ -1,0 +1,28 @@
+import is from '@sindresorhus/is';
+import ow from '../..';
+import {Predicate} from '../predicates/predicate';
+
+const ofTypeDeep = (input: any, predicate: Predicate): boolean => {
+	if (!is.plainObject(input)) {
+		ow(input, predicate);
+
+		return true;
+	}
+
+	return Object.keys(input).every(key => ofTypeDeep(input[key], predicate));
+};
+
+/**
+ * Test all the values in the object against a provided predicate.
+ *
+ * @hidden
+ * @param input Input object
+ * @param predicate Predicate to test every value in the input object against.
+ */
+export default (input: any, predicate: Predicate): boolean | string => {
+	try {
+		return ofTypeDeep(input, predicate);
+	} catch (err) {
+		return err.message;
+	}
+};

--- a/source/test/object.ts
+++ b/source/test/object.ts
@@ -33,6 +33,15 @@ test('object.valuesOfType', t => {
 	t.throws(() => m({unicorn: 'a', rainbow: 'b'}, m.object.valuesOfType(m.string.minLength(2))), 'Expected string to have a minimum length of `2`, got `a`');
 });
 
+test('object.valuesOfTypeDeep', t => {
+	t.notThrows(() => m({unicorn: '🦄'}, m.object.deepValuesOfType(m.string)));
+	t.notThrows(() => m({unicorn: '🦄', rainbow: '🌈'}, m.object.deepValuesOfType(m.string)));
+	t.notThrows(() => m({unicorn: {key: '🦄', value: '🌈'}}, m.object.deepValuesOfType(m.string)));
+	t.notThrows(() => m({a: {b: {c: {d: 1}, e: 2}, f: 3}}, m.object.deepValuesOfType(m.number)));
+	t.throws(() => m({unicorn: {key: '🦄', value: 1}}, m.object.deepValuesOfType(m.string)), 'Expected argument to be of type `string` but received type `number`');
+	t.throws(() => m({a: {b: {c: {d: 1}, e: '2'}, f: 3}}, m.object.deepValuesOfType(m.number)), 'Expected argument to be of type `number` but received type `string`');
+});
+
 test('object.deepEqual', t => {
 	t.notThrows(() => m({unicorn: '🦄'}, m.object.deepEqual({unicorn: '🦄'})));
 	t.notThrows(() => m({unicorn: '🦄', rain: {bow: '🌈'}}, m.object.deepEqual({unicorn: '🦄', rain: {bow: '🌈'}})));


### PR DESCRIPTION
Fixes #51. 

Added the type definitions for `is-plain-obj` manually here. Will try to PR it to DefinitelyTyped when I find some time. Feel free to provide feedback in the meantime.