### PR TITLE
Fix build

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
 		"node": ">=6"
 	},
 	"scripts": {
-		"prerelease": "npm run build && npm run docs",
+		"prerelease": "npm run build",
 		"pretest": "npm run compile -- --sourceMap",
 		"test": "npm run lint && nyc ava dist/test",
 		"lint": "tslint --format stylish --project .",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,4 +1,5 @@
 'use strict';
+const path = require('path');
 const webpack = require('webpack');
 const license = require('license-webpack-plugin');
 const AddModuleExportsPlugin = require('add-module-exports-webpack-plugin');
@@ -10,7 +11,8 @@ module.exports = {
 	node: false,
 	devtool: 'source-map',
 	output: {
-		filename: 'dist/index.js',
+		path: path.join(__dirname, 'dist'),
+		filename: 'index.js',
 		libraryTarget: 'commonjs2'
 	},
 	resolve: {
@@ -23,7 +25,7 @@ module.exports = {
 		new AddModuleExportsPlugin(),
 		new license.LicenseWebpackPlugin({
 			pattern: /.*/,
-			outputFilename: 'dist/licenses.txt'
+			outputFilename: 'licenses.txt'
 		})
 	],
 	module: {


### PR DESCRIPTION
Apparently our build was "broken" as webpack was outputting the files in `dist/dist` which is weird. It looks like the `output.path` property defaults to `dist`, although I can't find any documentation that confirms this. That's why I set the `output.path` property explicitly although it also works without it, but just to be sure that this behaviour is not a bug or something.

Also removed the generation of the docs upon prerelease because it's automatically done by Travis now.