### PR TITLE
Fix prepublish hook - fixes #64

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
 		"node": ">=6"
 	},
 	"scripts": {
-		"prerelease": "npm run build",
+		"prepublishOnly": "npm run build",
 		"pretest": "npm run compile -- --sourceMap",
 		"test": "npm run lint && nyc ava dist/test",
 		"lint": "tslint --format stylish --project .",
@@ -47,6 +47,7 @@
 		"object"
 	],
 	"devDependencies": {
+		"@sindresorhus/is": "^0.8.0",
 		"@types/dot-prop": "^4.2.0",
 		"@types/highlight.js": "^9.12.2",
 		"@types/lodash.isequal": "^4.5.2",
@@ -57,12 +58,15 @@
 		"awesome-typescript-loader": "^5.0.0",
 		"codecov": "^3.0.0",
 		"del-cli": "^1.1.0",
+		"dot-prop": "^4.2.0",
 		"license-webpack-plugin": "^1.1.1",
+		"lodash.isequal": "^4.5.0",
 		"nyc": "^11.2.1",
 		"tslint": "^5.9.1",
 		"tslint-xo": "^0.7.0",
 		"typedoc": "^0.11.1",
 		"typescript": "^2.8.1",
+		"vali-date": "^1.0.0",
 		"webpack": "^4.3.0",
 		"webpack-cli": "^2.0.13"
 	},
@@ -71,11 +75,5 @@
 		"exclude": [
 			"dist/test"
 		]
-	},
-	"dependencies": {
-		"@sindresorhus/is": "^0.8.0",
-		"dot-prop": "^4.2.0",
-		"lodash.isequal": "^4.5.0",
-		"vali-date": "^1.0.0"
 	}
 }


### PR DESCRIPTION
This PR fixes #64. The hook was just named wrong as `prerelease` does not exist https://docs.npmjs.com/misc/scripts.