### PR TITLE
Add support for chained not operators

### DIFF
--- a/source/lib/operators/not.ts
+++ b/source/lib/operators/not.ts
@@ -1,4 +1,15 @@
-import {Predicate, validatorSymbol} from '../predicates/predicate';
+import {Predicate} from '../predicates/predicate';
+
+/**
+ * @hidden
+ */
+const createMessage = (message: string) => {
+	if (message.startsWith('[NOT]')) {
+		return message.slice(6);
+	}
+
+	return `[NOT] ${message}`;
+};
 
 /**
  * Operator which inverts all the validations.
@@ -7,16 +18,16 @@ import {Predicate, validatorSymbol} from '../predicates/predicate';
  * @param predictate Predicate to wrap inside the operator.
  */
 export const not = <T, P extends Predicate<T>>(predicate: P) => {
+	const addValidator = predicate.addValidator.bind(predicate);
+
 	predicate.addValidator = validator => {
 		const fn = validator.validator;
 		const message = validator.message;
 
-		validator.message = (x: T) => `[NOT] ${message(x)}`;
+		validator.message = (x: T) => createMessage(message(x));
 		validator.validator = (x: T) => !fn(x);
 
-		predicate[validatorSymbol].push(validator);
-
-		return predicate;
+		return addValidator(validator);
 	};
 
 	return predicate;

--- a/source/lib/predicates/predicate.ts
+++ b/source/lib/predicates/predicate.ts
@@ -22,11 +22,6 @@ export interface Context<T> {
 /**
  * @hidden
  */
-export const validatorSymbol = Symbol('validators');
-
-/**
- * @hidden
- */
 export class Predicate<T = any> implements BasePredicate<T> {
 	constructor(
 		type: string,
@@ -53,13 +48,6 @@ export class Predicate<T = any> implements BasePredicate<T> {
 				throw new ArgumentError(message(value, result), main);
 			}
 		}
-	}
-
-	/**
-	 * @hidden
-	 */
-	get [validatorSymbol]() {
-		return this.context.validators;
 	}
 
 	/**

--- a/source/test/test.ts
+++ b/source/test/test.ts
@@ -5,7 +5,11 @@ test('not', t => {
 	t.notThrows(() => m(1, m.number.not.infinite));
 	t.notThrows(() => m(1, m.number.not.infinite.greaterThan(5)));
 	t.notThrows(() => m('foo!', m.string.not.alphanumeric));
+	t.notThrows(() => m('', m.string.not.not.empty));
+	t.notThrows(() => m('foo!', m.string.not.not.not.empty));
 	t.throws(() => m('', m.string.not.empty), '[NOT] Expected string to be empty, got ``');
+	t.throws(() => m('foo!', m.string.not.not.empty), 'Expected string to be empty, got `foo!`');
+	t.throws(() => m('', m.string.not.not.not.empty), '[NOT] Expected string to be empty, got ``');
 });
 
 test('is', t => {


### PR DESCRIPTION
This PR adds support for chained not operators.

```ts
ow('', m.string.not.not.empty);


ow('foo!', m.string.not.not.empty);
//=> ArgumentError: Expected string to be empty, got `foo!`
```

So it also strips off duplicate `[NOT]` prefixes from the error message.

One downside of this approach is that this doesn't fail

```ts
ow('foo', ow.string.not.empty.not.length(3));
```

Because now it checks if the string is `not empty`, but because of the second `not`, we have `not not length 3` which results in `not empty and length 3`. Not really sure what we should do in this scenario.