### PR TITLE
Invert only the following predicate with the 'not' operator

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -128,7 +128,7 @@ The following predicates are available on every type.
 
 #### not
 
-Inverts the following predicates.
+Inverts the following predicate.
 
 ```ts
 ow(1, ow.number.not.infinite);

--- a/source/lib/operators/not.ts
+++ b/source/lib/operators/not.ts
@@ -1,12 +1,14 @@
 import {Predicate, validatorSymbol} from '../predicates/predicate';
 
 /**
- * Operator which inverts all the validations.
+ * Operator which inverts the following validation.
  *
  * @hidden
  * @param predictate Predicate to wrap inside the operator.
  */
 export const not = <T, P extends Predicate<T>>(predicate: P) => {
+	const originalAddValidator = predicate.addValidator;
+
 	predicate.addValidator = validator => {
 		const fn = validator.validator;
 		const message = validator.message;
@@ -15,6 +17,8 @@ export const not = <T, P extends Predicate<T>>(predicate: P) => {
 		validator.validator = (x: T) => !fn(x);
 
 		predicate[validatorSymbol].push(validator);
+
+		predicate.addValidator = originalAddValidator;
 
 		return predicate;
 	};

--- a/source/test/test.ts
+++ b/source/test/test.ts
@@ -2,9 +2,11 @@ import test from 'ava';
 import m from '..';
 
 test('not', t => {
-	t.notThrows(() => m(1, m.number.not.infinite));
-	t.notThrows(() => m(1, m.number.not.infinite.greaterThan(5)));
 	t.notThrows(() => m('foo!', m.string.not.alphanumeric));
+	t.notThrows(() => m(1, m.number.not.infinite));
+	t.notThrows(() => m(1, m.number.not.infinite.not.greaterThan(5)));
+	t.throws(() => m(6, m.number.not.infinite.not.greaterThan(5)));
+	t.throws(() => m(1, m.number.not.infinite.greaterThan(5)), 'Expected 1 to be greater than 5');
 	t.throws(() => m('', m.string.not.empty), '[NOT] Expected string to be empty, got ``');
 });
 

--- a/source/test/test.ts
+++ b/source/test/test.ts
@@ -6,7 +6,6 @@ test('not', t => {
 	t.notThrows(() => m(1, m.number.not.infinite));
 	t.notThrows(() => m(1, m.number.not.infinite.not.greaterThan(5)));
 	t.throws(() => m(6, m.number.not.infinite.not.greaterThan(5)));
-	t.throws(() => m(1, m.number.not.infinite.greaterThan(5)), 'Expected 1 to be greater than 5');
 	t.notThrows(() => m('foo!', m.string.not.alphabetical));
 	t.notThrows(() => m('foo!', m.string.not.alphanumeric));
 	t.notThrows(() => m('foo!', m.string.label('foo').not.alphanumeric));


### PR DESCRIPTION
This PR changes the `not` operator from inverting all of the following predicates to only inverting the single following predicate.

```
ow(1, ow.number.not.infinite.not.greaterThan(5)) // will not throw

ow(1, ow.number.not.infinite.greaterThan(5)) // will throw
```

As ow is designed for human readability I believe that this is a more natural API (at least for English speakers) as the above code would be read
```
1 is a number and not infinite and not greater than 5.
```
and
```
1 is a number and not infinite and greater than 5.
```
respectively.