### PR TITLE
Add badges for gzip size & install size

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -4,7 +4,7 @@
 	<br>
 </p>
 
-[![Build Status](https://travis-ci.org/sindresorhus/ow.svg?branch=master)](https://travis-ci.org/sindresorhus/ow) [![Coverage Status](https://codecov.io/gh/sindresorhus/ow/branch/master/graph/badge.svg)](https://codecov.io/gh/sindresorhus/ow)
+[![Build Status](https://travis-ci.org/sindresorhus/ow.svg?branch=master)](https://travis-ci.org/sindresorhus/ow) [![Coverage Status](https://codecov.io/gh/sindresorhus/ow/branch/master/graph/badge.svg)](https://codecov.io/gh/sindresorhus/ow) [![gzip size](http://img.badgesize.io/https://cdn.jsdelivr.net/npm/ow/dist/index.js?compression=gzip)](https://cdn.jsdelivr.net/npm/ow/dist/index.js) [![install size](https://packagephobia.now.sh/badge?p=ow)](https://packagephobia.now.sh/result?p=ow)
 
 > Function argument validation for humans
 


### PR DESCRIPTION
This adds two badges to the `README.md`

- **gzip size**: displays the size of the dist after gzip compression
- **install size**: displays the npm install size of `ow` plus it's dependencies (in this case 0 😄)