### PR TITLE
Add support for predicate labels

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -159,6 +159,20 @@ ow(5, ow.number.is(x => greaterThan(10, x)));
 //=> ArgumentError: Expected `5` to be greater than `10`
 ```
 
+#### label(string)
+
+This assigns a custom label to be used in any error messages. It is useful for making error messages more user-friendly by including the name of the variable which failed validation.
+
+This predicate does not add any additional validation.
+
+```ts
+ow('', ow.string.nonEmpty);
+//=> ArgumentError: Expected string to not be empty
+
+ow('', ow.string.label('foo').nonEmpty);
+//=> ArgumentError: Expected string `foo` to not be empty
+```
+
 
 ## Maintainers
 

--- a/source/index.ts
+++ b/source/index.ts
@@ -238,55 +238,55 @@ Object.defineProperties(main, {
 		get: () => new WeakSetPredicate()
 	},
 	function: {
-		get: () => new Predicate('function')
+		get: () => new Predicate('Function')
 	},
 	buffer: {
-		get: () => new Predicate('buffer')
+		get: () => new Predicate('Buffer')
 	},
 	regExp: {
-		get: () => new Predicate('regExp')
+		get: () => new Predicate('RegExp')
 	},
 	promise: {
-		get: () => new Predicate('promise')
+		get: () => new Predicate('Promise')
 	},
 	typedArray: {
-		get: () => new Predicate('typedArray')
+		get: () => new Predicate('TypedArray')
 	},
 	int8Array: {
-		get: () => new Predicate('int8Array')
+		get: () => new Predicate('Int8Array')
 	},
 	uint8Array: {
-		get: () => new Predicate('uint8Array')
+		get: () => new Predicate('Uint8Array')
 	},
 	uint8ClampedArray: {
-		get: () => new Predicate('uint8ClampedArray')
+		get: () => new Predicate('Uint8ClampedArray')
 	},
 	int16Array: {
-		get: () => new Predicate('int16Array')
+		get: () => new Predicate('Int16Array')
 	},
 	uint16Array: {
-		get: () => new Predicate('uint16Array')
+		get: () => new Predicate('Uint16Array')
 	},
 	int32Array: {
-		get: () => new Predicate('int32Array')
+		get: () => new Predicate('Int32Array')
 	},
 	uint32Array: {
-		get: () => new Predicate('uint32Array')
+		get: () => new Predicate('Uint32Array')
 	},
 	float32Array: {
-		get: () => new Predicate('float32Array')
+		get: () => new Predicate('Float32Array')
 	},
 	float64Array: {
-		get: () => new Predicate('float64Array')
+		get: () => new Predicate('Float64Array')
 	},
 	arrayBuffer: {
-		get: () => new Predicate('arrayBuffer')
+		get: () => new Predicate('ArrayBuffer')
 	},
 	dataView: {
-		get: () => new Predicate('dataView')
+		get: () => new Predicate('DataView')
 	},
 	iterable: {
-		get: () => new Predicate('iterable')
+		get: () => new Predicate('Iterable')
 	}
 });
 

--- a/source/lib/operators/not.ts
+++ b/source/lib/operators/not.ts
@@ -11,7 +11,7 @@ export const not = <T, P extends Predicate<T>>(predicate: P) => {
 		const fn = validator.validator;
 		const message = validator.message;
 
-		validator.message = (x: T, label) => `[NOT] ${message(x, label)}`;
+		validator.message = (x: T, label: string) => `[NOT] ${message(x, label)}`;
 		validator.validator = (x: T) => !fn(x);
 
 		predicate[validatorSymbol].push(validator);

--- a/source/lib/operators/not.ts
+++ b/source/lib/operators/not.ts
@@ -11,7 +11,7 @@ export const not = <T, P extends Predicate<T>>(predicate: P) => {
 		const fn = validator.validator;
 		const message = validator.message;
 
-		validator.message = (x: T) => `[NOT] ${message(x)}`;
+		validator.message = (x: T, label) => `[NOT] ${message(x, label)}`;
 		validator.validator = (x: T) => !fn(x);
 
 		predicate[validatorSymbol].push(validator);

--- a/source/lib/predicates/array.ts
+++ b/source/lib/predicates/array.ts
@@ -17,7 +17,7 @@ export class ArrayPredicate<T = any> extends Predicate<T[]> {
 	 */
 	length(length: number) {
 		return this.addValidator({
-			message: value => `Expected array to have length \`${length}\`, got \`${value.length}\``,
+			message: (value, label) => `Expected ${label} to have length \`${length}\`, got \`${value.length}\``,
 			validator: value => value.length === length
 		});
 	}
@@ -29,7 +29,7 @@ export class ArrayPredicate<T = any> extends Predicate<T[]> {
 	 */
 	minLength(length: number) {
 		return this.addValidator({
-			message: value => `Expected array to have a minimum length of \`${length}\`, got \`${value.length}\``,
+			message: (value, label) => `Expected ${label} to have a minimum length of \`${length}\`, got \`${value.length}\``,
 			validator: value => value.length >= length
 		});
 	}
@@ -41,7 +41,7 @@ export class ArrayPredicate<T = any> extends Predicate<T[]> {
 	 */
 	maxLength(length: number) {
 		return this.addValidator({
-			message: value => `Expected array to have a maximum length of \`${length}\`, got \`${value.length}\``,
+			message: (value, label) => `Expected ${label} to have a maximum length of \`${length}\`, got \`${value.length}\``,
 			validator: value => value.length <= length
 		});
 	}
@@ -53,7 +53,7 @@ export class ArrayPredicate<T = any> extends Predicate<T[]> {
 	 */
 	startsWith(searchElement: T) {
 		return this.addValidator({
-			message: value => `Expected array to start with \`${searchElement}\`, got \`${value[0]}\``,
+			message: (value, label) => `Expected ${label} to start with \`${searchElement}\`, got \`${value[0]}\``,
 			validator: value => value[0] === searchElement
 		});
 	}
@@ -65,7 +65,7 @@ export class ArrayPredicate<T = any> extends Predicate<T[]> {
 	 */
 	endsWith(searchElement: T) {
 		return this.addValidator({
-			message: value => `Expected array to end with \`${searchElement}\`, got \`${value[value.length - 1]}\``,
+			message: (value, label) => `Expected ${label} to end with \`${searchElement}\`, got \`${value[value.length - 1]}\``,
 			validator: value => value[value.length - 1] === searchElement
 		});
 	}
@@ -77,7 +77,7 @@ export class ArrayPredicate<T = any> extends Predicate<T[]> {
 	 */
 	includes(...searchElements: T[]) {
 		return this.addValidator({
-			message: value => `Expected array to include all elements of \`${JSON.stringify(searchElements)}\`, got \`${JSON.stringify(value)}\``,
+			message: (value, label) => `Expected ${label} to include all elements of \`${JSON.stringify(searchElements)}\`, got \`${JSON.stringify(value)}\``,
 			validator: value => searchElements.every(el => value.indexOf(el) !== -1)
 		});
 	}
@@ -89,7 +89,7 @@ export class ArrayPredicate<T = any> extends Predicate<T[]> {
 	 */
 	includesAny(...searchElements: T[]) {
 		return this.addValidator({
-			message: value => `Expected array to include any element of \`${JSON.stringify(searchElements)}\`, got \`${JSON.stringify(value)}\``,
+			message: (value, label) => `Expected ${label} to include any element of \`${JSON.stringify(searchElements)}\`, got \`${JSON.stringify(value)}\``,
 			validator: value => searchElements.some(el => value.indexOf(el) !== -1)
 		});
 	}
@@ -99,7 +99,7 @@ export class ArrayPredicate<T = any> extends Predicate<T[]> {
 	 */
 	get empty() {
 		return this.addValidator({
-			message: value => `Expected array to be empty, got \`${JSON.stringify(value)}\``,
+			message: (value, label) => `Expected ${label} to be empty, got \`${JSON.stringify(value)}\``,
 			validator: value => value.length === 0
 		});
 	}
@@ -109,7 +109,7 @@ export class ArrayPredicate<T = any> extends Predicate<T[]> {
 	 */
 	get nonEmpty() {
 		return this.addValidator({
-			message: () => 'Expected array to not be empty',
+			message: (_, label) => `Expected ${label} to not be empty`,
 			validator: value => value.length > 0
 		});
 	}
@@ -121,7 +121,7 @@ export class ArrayPredicate<T = any> extends Predicate<T[]> {
 	 */
 	deepEqual(expected: T[]) {
 		return this.addValidator({
-			message: value => `Expected array to be deeply equal to \`${JSON.stringify(expected)}\`, got \`${JSON.stringify(value)}\``,
+			message: (value, label) => `Expected ${label} to be deeply equal to \`${JSON.stringify(expected)}\`, got \`${JSON.stringify(value)}\``,
 			validator: value => isEqual(value, expected)
 		});
 	}
@@ -135,7 +135,7 @@ export class ArrayPredicate<T = any> extends Predicate<T[]> {
 		let error: string;
 
 		return this.addValidator({
-			message: () => error,
+			message: (_, label) => `(${label}) ${error}`,
 			validator: value => {
 				try {
 					for (const item of value) {

--- a/source/lib/predicates/boolean.ts
+++ b/source/lib/predicates/boolean.ts
@@ -13,7 +13,7 @@ export class BooleanPredicate extends Predicate<boolean> {
 	 */
 	get true() {
 		return this.addValidator({
-			message: value => `Expected ${value} to be true`,
+			message: (value, label) => `Expected ${label} ${value} to be true`,
 			validator: value => value === true
 		});
 	}
@@ -23,7 +23,7 @@ export class BooleanPredicate extends Predicate<boolean> {
 	 */
 	get false() {
 		return this.addValidator({
-			message: value => `Expected ${value} to be false`,
+			message: (value, label) => `Expected ${label} ${value} to be false`,
 			validator: value => value === false
 		});
 	}

--- a/source/lib/predicates/boolean.ts
+++ b/source/lib/predicates/boolean.ts
@@ -13,7 +13,7 @@ export class BooleanPredicate extends Predicate<boolean> {
 	 */
 	get true() {
 		return this.addValidator({
-			message: (value, label) => `Expected ${label} ${value} to be true`,
+			message: (value, label) => `Expected ${label} to be true, got ${value}`,
 			validator: value => value === true
 		});
 	}
@@ -23,7 +23,7 @@ export class BooleanPredicate extends Predicate<boolean> {
 	 */
 	get false() {
 		return this.addValidator({
-			message: (value, label) => `Expected ${label} ${value} to be false`,
+			message: (value, label) => `Expected ${label} to be false, got ${value}`,
 			validator: value => value === false
 		});
 	}

--- a/source/lib/predicates/date.ts
+++ b/source/lib/predicates/date.ts
@@ -15,7 +15,7 @@ export class DatePredicate extends Predicate<Date> {
 	 */
 	before(date: Date) {
 		return this.addValidator({
-			message: value => `Expected ${value.toISOString()} to be before ${date.toISOString()}`,
+			message: (value, label) => `Expected ${label} ${value.toISOString()} to be before ${date.toISOString()}`,
 			validator: value => value.getTime() < date.getTime()
 		});
 	}
@@ -27,7 +27,7 @@ export class DatePredicate extends Predicate<Date> {
 	 */
 	after(date: Date) {
 		return this.addValidator({
-			message: value => `Expected ${value.toISOString()} to be after ${date.toISOString()}`,
+			message: (value, label) => `Expected ${label} ${value.toISOString()} to be after ${date.toISOString()}`,
 			validator: value => value.getTime() > date.getTime()
 		});
 	}

--- a/source/lib/predicates/error.ts
+++ b/source/lib/predicates/error.ts
@@ -15,7 +15,7 @@ export class ErrorPredicate extends Predicate<Error> {
 	 */
 	name(expected: string) {
 		return this.addValidator({
-			message: error => `Expected error to have name \`${expected}\`, got \`${error.name}\``,
+			message: (error, label) => `Expected ${label} to have name \`${expected}\`, got \`${error.name}\``,
 			validator: error => error.name === expected
 		});
 	}
@@ -27,7 +27,7 @@ export class ErrorPredicate extends Predicate<Error> {
 	 */
 	message(expected: string) {
 		return this.addValidator({
-			message: error => `Expected error message to be \`${expected}\`, got \`${error.message}\``,
+			message: (error, label) => `Expected ${label} message to be \`${expected}\`, got \`${error.message}\``,
 			validator: error => error.message === expected
 		});
 	}
@@ -39,7 +39,7 @@ export class ErrorPredicate extends Predicate<Error> {
 	 */
 	messageIncludes(message: string) {
 		return this.addValidator({
-			message: error => `Expected error message to include \`${message}\`, got \`${error.message}\``,
+			message: (error, label) => `Expected ${label} message to include \`${message}\`, got \`${error.message}\``,
 			validator: error => error.message.includes(message)
 		});
 	}
@@ -51,7 +51,7 @@ export class ErrorPredicate extends Predicate<Error> {
 	 */
 	hasKeys(...keys: string[]) {
 		return this.addValidator({
-			message: () => `Expected error message to have keys \`${keys.join('`, `')}\``,
+			message: (_, label) => `Expected ${label} message to have keys \`${keys.join('`, `')}\``,
 			validator: error => keys.every(key => error.hasOwnProperty(key))
 		});
 	}
@@ -63,7 +63,7 @@ export class ErrorPredicate extends Predicate<Error> {
 	 */
 	instanceOf(instance: any) {
 		return this.addValidator({
-			message: error => `Expected \`${error.name}\` to be of type \`${instance.name}\``,
+			message: (error, label) => `Expected ${label} \`${error.name}\` to be of type \`${instance.name}\``,
 			validator: error => error instanceof instance
 		});
 	}

--- a/source/lib/predicates/map.ts
+++ b/source/lib/predicates/map.ts
@@ -8,7 +8,7 @@ export class MapPredicate<T1 = any, T2 = any> extends Predicate<Map<T1, T2>> {
 	 * @hidden
 	 */
 	constructor(context?: Context<Map<T1, T2>>) {
-		super('map', context);
+		super('map', context, 'Map');
 	}
 
 	/**
@@ -18,7 +18,7 @@ export class MapPredicate<T1 = any, T2 = any> extends Predicate<Map<T1, T2>> {
 	 */
 	size(size: number) {
 		return this.addValidator({
-			message: map => `Expected Map to have size \`${size}\`, got \`${map.size}\``,
+			message: (map, label) => `Expected ${label} to have size \`${size}\`, got \`${map.size}\``,
 			validator: map => map.size === size
 		});
 	}
@@ -30,7 +30,7 @@ export class MapPredicate<T1 = any, T2 = any> extends Predicate<Map<T1, T2>> {
 	 */
 	minSize(size: number) {
 		return this.addValidator({
-			message: map => `Expected Map to have a minimum size of \`${size}\`, got \`${map.size}\``,
+			message: (map, label) => `Expected ${label} to have a minimum size of \`${size}\`, got \`${map.size}\``,
 			validator: map => map.size >= size
 		});
 	}
@@ -42,7 +42,7 @@ export class MapPredicate<T1 = any, T2 = any> extends Predicate<Map<T1, T2>> {
 	 */
 	maxSize(size: number) {
 		return this.addValidator({
-			message: map => `Expected Map to have a maximum size of \`${size}\`, got \`${map.size}\``,
+			message: (map, label) => `Expected ${label} to have a maximum size of \`${size}\`, got \`${map.size}\``,
 			validator: map => map.size <= size
 		});
 	}
@@ -54,7 +54,7 @@ export class MapPredicate<T1 = any, T2 = any> extends Predicate<Map<T1, T2>> {
 	 */
 	hasKeys(...keys: T1[]) {
 		return this.addValidator({
-			message: (_, missingKeys) => `Expected Map to have keys \`${JSON.stringify(missingKeys)}\``,
+			message: (_, label, missingKeys) => `Expected ${label} to have keys \`${JSON.stringify(missingKeys)}\``,
 			validator: map => hasItems(map, keys)
 		});
 	}
@@ -66,7 +66,7 @@ export class MapPredicate<T1 = any, T2 = any> extends Predicate<Map<T1, T2>> {
 	 */
 	hasAnyKeys(...keys: T1[]) {
 		return this.addValidator({
-			message: () => `Expected Map to have any key of \`${JSON.stringify(keys)}\``,
+			message: (_, label) => `Expected ${label} to have any key of \`${JSON.stringify(keys)}\``,
 			validator: map => keys.some(key => map.has(key))
 		});
 	}
@@ -78,7 +78,7 @@ export class MapPredicate<T1 = any, T2 = any> extends Predicate<Map<T1, T2>> {
 	 */
 	hasValues(...values: T2[]) {
 		return this.addValidator({
-			message: (_, missingValues) => `Expected Map to have values \`${JSON.stringify(missingValues)}\``,
+			message: (_, label, missingValues) => `Expected ${label} to have values \`${JSON.stringify(missingValues)}\``,
 			validator: map => hasItems(new Set(map.values()), values)
 		});
 	}
@@ -90,7 +90,7 @@ export class MapPredicate<T1 = any, T2 = any> extends Predicate<Map<T1, T2>> {
 	 */
 	hasAnyValues(...values: T2[]) {
 		return this.addValidator({
-			message: () => `Expected Map to have any value of \`${JSON.stringify(values)}\``,
+			message: (_, label) => `Expected ${label} to have any value of \`${JSON.stringify(values)}\``,
 			validator: map => {
 				const valueSet = new Set(map.values());
 
@@ -106,7 +106,7 @@ export class MapPredicate<T1 = any, T2 = any> extends Predicate<Map<T1, T2>> {
 	 */
 	keysOfType(predicate: Predicate<T1>) {
 		return this.addValidator({
-			message: (_, error) => error,
+			message: (_, label, error) => `(${label}) ${error}`,
 			validator: map => ofType(map.keys(), predicate)
 		});
 	}
@@ -118,7 +118,7 @@ export class MapPredicate<T1 = any, T2 = any> extends Predicate<Map<T1, T2>> {
 	 */
 	valuesOfType(predicate: Predicate<T2>) {
 		return this.addValidator({
-			message: (_, error) => error,
+			message: (_, label, error) => `(${label}) ${error}`,
 			validator: map => ofType(map.values(), predicate)
 		});
 	}
@@ -128,7 +128,7 @@ export class MapPredicate<T1 = any, T2 = any> extends Predicate<Map<T1, T2>> {
 	 */
 	get empty() {
 		return this.addValidator({
-			message: map => `Expected Map to be empty, got \`${JSON.stringify(Array.from(map))}\``,
+			message: (map, label) => `Expected ${label} to be empty, got \`${JSON.stringify(Array.from(map))}\``,
 			validator: map => map.size === 0
 		});
 	}
@@ -138,7 +138,7 @@ export class MapPredicate<T1 = any, T2 = any> extends Predicate<Map<T1, T2>> {
 	 */
 	get nonEmpty() {
 		return this.addValidator({
-			message: () => 'Expected Map to not be empty',
+			message: (_, label) => `Expected ${label} to not be empty`,
 			validator: map => map.size > 0
 		});
 	}
@@ -150,7 +150,7 @@ export class MapPredicate<T1 = any, T2 = any> extends Predicate<Map<T1, T2>> {
 	 */
 	deepEqual(expected: Map<T1, T2>) {
 		return this.addValidator({
-			message: map => `Expected Map to be deeply equal to \`${JSON.stringify(Array.from(expected))}\`, got \`${JSON.stringify(Array.from(map))}\``,
+			message: (map, label) => `Expected ${label} to be deeply equal to \`${JSON.stringify(Array.from(expected))}\`, got \`${JSON.stringify(Array.from(map))}\``,
 			validator: map => isEqual(map, expected)
 		});
 	}

--- a/source/lib/predicates/map.ts
+++ b/source/lib/predicates/map.ts
@@ -8,7 +8,7 @@ export class MapPredicate<T1 = any, T2 = any> extends Predicate<Map<T1, T2>> {
 	 * @hidden
 	 */
 	constructor(context?: Context<Map<T1, T2>>) {
-		super('map', context, 'Map');
+		super('Map', context);
 	}
 
 	/**

--- a/source/lib/predicates/number.ts
+++ b/source/lib/predicates/number.ts
@@ -17,7 +17,7 @@ export class NumberPredicate extends Predicate<number> {
 	 */
 	inRange(start: number, end: number) {
 		return this.addValidator({
-			message: value => `Expected ${value} to be in range [${start}..${end}]`,
+			message: (value, label) => `Expected ${label} ${value} to be in range [${start}..${end}]`,
 			validator: value => is.inRange(value, [start, end])
 		});
 	}
@@ -29,7 +29,7 @@ export class NumberPredicate extends Predicate<number> {
 	 */
 	greaterThan(x: number) {
 		return this.addValidator({
-			message: value => `Expected ${value} to be greater than ${x}`,
+			message: (value, label) => `Expected ${label} ${value} to be greater than ${x}`,
 			validator: value => value > x
 		});
 	}
@@ -41,7 +41,7 @@ export class NumberPredicate extends Predicate<number> {
 	 */
 	greaterThanOrEqual(x: number) {
 		return this.addValidator({
-			message: value => `Expected ${value} to be greater than or equal to ${x}`,
+			message: (value, label) => `Expected ${label} ${value} to be greater than or equal to ${x}`,
 			validator: value => value >= x
 		});
 	}
@@ -53,7 +53,7 @@ export class NumberPredicate extends Predicate<number> {
 	 */
 	lessThan(x: number) {
 		return this.addValidator({
-			message: value => `Expected ${value} to be less than ${x}`,
+			message: (value, label) => `Expected ${label} ${value} to be less than ${x}`,
 			validator: value => value < x
 		});
 	}
@@ -65,7 +65,7 @@ export class NumberPredicate extends Predicate<number> {
 	 */
 	lessThanOrEqual(x: number) {
 		return this.addValidator({
-			message: value => `Expected ${value} to be less than or equal to ${x}`,
+			message: (value, label) => `Expected ${label} ${value} to be less than or equal to ${x}`,
 			validator: value => value <= x
 		});
 	}
@@ -77,7 +77,7 @@ export class NumberPredicate extends Predicate<number> {
 	 */
 	equal(expected: number) {
 		return this.addValidator({
-			message: value => `Expected ${value} to be equal to ${expected}`,
+			message: (value, label) => `Expected ${label} ${value} to be equal to ${expected}`,
 			validator: value => value === expected
 		});
 	}
@@ -87,7 +87,7 @@ export class NumberPredicate extends Predicate<number> {
 	 */
 	get integer() {
 		return this.addValidator({
-			message: value => `Expected ${value} to be an integer`,
+			message: (value, label) => `Expected ${label} ${value} to be an integer`,
 			validator: value => is.integer(value)
 		});
 	}
@@ -97,7 +97,7 @@ export class NumberPredicate extends Predicate<number> {
 	 */
 	get finite() {
 		return this.addValidator({
-			message: value => `Expected ${value} to be finite`,
+			message: (value, label) => `Expected ${label} ${value} to be finite`,
 			validator: value => !is.infinite(value)
 		});
 	}
@@ -107,7 +107,7 @@ export class NumberPredicate extends Predicate<number> {
 	 */
 	get infinite() {
 		return this.addValidator({
-			message: value => `Expected ${value} to be infinite`,
+			message: (value, label) => `Expected ${label} ${value} to be infinite`,
 			validator: value => is.infinite(value)
 		});
 	}
@@ -117,7 +117,7 @@ export class NumberPredicate extends Predicate<number> {
 	 */
 	get positive() {
 		return this.addValidator({
-			message: value => `Expected ${value} to be positive`,
+			message: (value, label) => `Expected ${label} ${value} to be positive`,
 			validator: value => value > 0
 		});
 	}
@@ -127,7 +127,7 @@ export class NumberPredicate extends Predicate<number> {
 	 */
 	get negative() {
 		return this.addValidator({
-			message: value => `Expected ${value} to be negative`,
+			message: (value, label) => `Expected ${label} ${value} to be negative`,
 			validator: value => value < 0
 		});
 	}

--- a/source/lib/predicates/number.ts
+++ b/source/lib/predicates/number.ts
@@ -17,7 +17,7 @@ export class NumberPredicate extends Predicate<number> {
 	 */
 	inRange(start: number, end: number) {
 		return this.addValidator({
-			message: (value, label) => `Expected ${label} ${value} to be in range [${start}..${end}]`,
+			message: (value, label) => `Expected ${label} to be in range [${start}..${end}], got ${value}`,
 			validator: value => is.inRange(value, [start, end])
 		});
 	}
@@ -29,7 +29,7 @@ export class NumberPredicate extends Predicate<number> {
 	 */
 	greaterThan(x: number) {
 		return this.addValidator({
-			message: (value, label) => `Expected ${label} ${value} to be greater than ${x}`,
+			message: (value, label) => `Expected ${label} to be greater than ${x}, got ${value}`,
 			validator: value => value > x
 		});
 	}
@@ -41,7 +41,7 @@ export class NumberPredicate extends Predicate<number> {
 	 */
 	greaterThanOrEqual(x: number) {
 		return this.addValidator({
-			message: (value, label) => `Expected ${label} ${value} to be greater than or equal to ${x}`,
+			message: (value, label) => `Expected ${label} to be greater than or equal to ${x}, got ${value}`,
 			validator: value => value >= x
 		});
 	}
@@ -53,7 +53,7 @@ export class NumberPredicate extends Predicate<number> {
 	 */
 	lessThan(x: number) {
 		return this.addValidator({
-			message: (value, label) => `Expected ${label} ${value} to be less than ${x}`,
+			message: (value, label) => `Expected ${label} to be less than ${x}, got ${value}`,
 			validator: value => value < x
 		});
 	}
@@ -65,7 +65,7 @@ export class NumberPredicate extends Predicate<number> {
 	 */
 	lessThanOrEqual(x: number) {
 		return this.addValidator({
-			message: (value, label) => `Expected ${label} ${value} to be less than or equal to ${x}`,
+			message: (value, label) => `Expected ${label} to be less than or equal to ${x}, got ${value}`,
 			validator: value => value <= x
 		});
 	}
@@ -77,7 +77,7 @@ export class NumberPredicate extends Predicate<number> {
 	 */
 	equal(expected: number) {
 		return this.addValidator({
-			message: (value, label) => `Expected ${label} ${value} to be equal to ${expected}`,
+			message: (value, label) => `Expected ${label} to be equal to ${expected}, got ${value}`,
 			validator: value => value === expected
 		});
 	}
@@ -87,7 +87,7 @@ export class NumberPredicate extends Predicate<number> {
 	 */
 	get integer() {
 		return this.addValidator({
-			message: (value, label) => `Expected ${label} ${value} to be an integer`,
+			message: (value, label) => `Expected ${label} to be an integer, got ${value}`,
 			validator: value => is.integer(value)
 		});
 	}
@@ -97,7 +97,7 @@ export class NumberPredicate extends Predicate<number> {
 	 */
 	get finite() {
 		return this.addValidator({
-			message: (value, label) => `Expected ${label} ${value} to be finite`,
+			message: (value, label) => `Expected ${label} to be finite, got ${value}`,
 			validator: value => !is.infinite(value)
 		});
 	}
@@ -107,7 +107,7 @@ export class NumberPredicate extends Predicate<number> {
 	 */
 	get infinite() {
 		return this.addValidator({
-			message: (value, label) => `Expected ${label} ${value} to be infinite`,
+			message: (value, label) => `Expected ${label} to be infinite, got ${value}`,
 			validator: value => is.infinite(value)
 		});
 	}
@@ -117,7 +117,7 @@ export class NumberPredicate extends Predicate<number> {
 	 */
 	get positive() {
 		return this.addValidator({
-			message: (value, label) => `Expected ${label} ${value} to be positive`,
+			message: (value, label) => `Expected ${label} to be positive, got ${value}`,
 			validator: value => value > 0
 		});
 	}
@@ -127,7 +127,7 @@ export class NumberPredicate extends Predicate<number> {
 	 */
 	get negative() {
 		return this.addValidator({
-			message: (value, label) => `Expected ${label} ${value} to be negative`,
+			message: (value, label) => `Expected ${label} to be negative, got ${value}`,
 			validator: value => value < 0
 		});
 	}

--- a/source/lib/predicates/object.ts
+++ b/source/lib/predicates/object.ts
@@ -19,7 +19,7 @@ export class ObjectPredicate extends Predicate<object> {
 	 */
 	get plain() {
 		return this.addValidator({
-			message: () => 'Expected object to be a plain object',
+			message: (_, label) => `Expected ${label} to be a plain object`,
 			validator: object => is.plainObject(object)
 		});
 	}
@@ -29,7 +29,7 @@ export class ObjectPredicate extends Predicate<object> {
 	 */
 	get empty() {
 		return this.addValidator({
-			message: object => `Expected object to be empty, got \`${JSON.stringify(object)}\``,
+			message: (object, label) => `Expected ${label} to be empty, got \`${JSON.stringify(object)}\``,
 			validator: object => Object.keys(object).length === 0
 		});
 	}
@@ -39,7 +39,7 @@ export class ObjectPredicate extends Predicate<object> {
 	 */
 	get nonEmpty() {
 		return this.addValidator({
-			message: () => 'Expected object to not be empty',
+			message: (_, label) => `Expected ${label} to not be empty`,
 			validator: object => Object.keys(object).length > 0
 		});
 	}
@@ -51,7 +51,7 @@ export class ObjectPredicate extends Predicate<object> {
 	 */
 	valuesOfType<T>(predicate: Predicate<T>) {
 		return this.addValidator({
-			message: (_, error) => error,
+			message: (_, label, error) => `(${label}) ${error}`,
 			validator: (object: any) => {
 				const values = Object.keys(object).map(key => object[key]);
 
@@ -67,7 +67,7 @@ export class ObjectPredicate extends Predicate<object> {
 	 */
 	deepValuesOfType<T>(predicate: Predicate<T>) {
 		return this.addValidator({
-			message: (_, error) => error,
+			message: (_, label, error) => `(${label}) ${error}`,
 			validator: (object: any) => ofTypeDeep(object, predicate)
 		});
 	}
@@ -79,7 +79,7 @@ export class ObjectPredicate extends Predicate<object> {
 	 */
 	deepEqual(expected: object) {
 		return this.addValidator({
-			message: object => `Expected object to be deeply equal to \`${JSON.stringify(expected)}\`, got \`${JSON.stringify(object)}\``,
+			message: (object, label) => `Expected ${label} to be deeply equal to \`${JSON.stringify(expected)}\`, got \`${JSON.stringify(object)}\``,
 			validator: object => isEqual(object, expected)
 		});
 	}
@@ -91,14 +91,14 @@ export class ObjectPredicate extends Predicate<object> {
 	 */
 	instanceOf(instance: any) {
 		return this.addValidator({
-			message: (object: any) => {
+			message: (object: any, label: string) => {
 				let name = object.constructor.name;
 
 				if (!name || name === 'Object') {
 					name = JSON.stringify(object);
 				}
 
-				return `Expected \`${name}\` to be of type \`${instance.name}\``;
+				return `Expected ${label} \`${name}\` to be of type \`${instance.name}\``;
 			},
 			validator: object => object instanceof instance
 		});
@@ -111,7 +111,7 @@ export class ObjectPredicate extends Predicate<object> {
 	 */
 	hasKeys(...keys: string[]) {
 		return this.addValidator({
-			message: (_, missingKeys) => `Expected object to have keys \`${JSON.stringify(missingKeys)}\``,
+			message: (_, label, missingKeys) => `Expected ${label} to have keys \`${JSON.stringify(missingKeys)}\``,
 			validator: object => hasItems({
 				has: item => dotProp.has(object, item)
 			}, keys)
@@ -125,7 +125,7 @@ export class ObjectPredicate extends Predicate<object> {
 	 */
 	hasAnyKeys(...keys: string[]) {
 		return this.addValidator({
-			message: () => `Expected object to have any key of \`${JSON.stringify(keys)}\``,
+			message: (_, label) => `Expected ${label} to have any key of \`${JSON.stringify(keys)}\``,
 			validator: (object: any) => keys.some(key => dotProp.has(object, key))
 		});
 	}

--- a/source/lib/predicates/predicate.ts
+++ b/source/lib/predicates/predicate.ts
@@ -30,19 +30,20 @@ export const validatorSymbol = Symbol('validators');
  */
 export class Predicate<T = any> implements BasePredicate<T> {
 	constructor(
-		type: string,
+		private readonly type: string,
 		private readonly context: Context<T> = {
 			validators: []
-		},
-		private readonly defaultLabel: string = type
+		}
 	) {
+		const x = this.type[0].toLowerCase() + this.type.slice(1);
+
 		this.addValidator({
 			message: value => {
 				// We do not include type in this label as we do for other messages, because it would be redundant.
 				const label = this.context.label || 'argument';
-				return `Expected ${label} to be of type \`${type}\` but received type \`${is(value)}\``;
+				return `Expected ${label} to be of type \`${x}\` but received type \`${is(value)}\``;
 			},
-			validator: value => (is as any)[type](value)
+			validator: value => (is as any)[x](value)
 		});
 	}
 
@@ -52,8 +53,8 @@ export class Predicate<T = any> implements BasePredicate<T> {
 	// tslint:disable completed-docs
 	[testSymbol](value: T, main: Ow) {
 		const label = this.context.label
-			? `${this.defaultLabel} ${this.context.label}`
-			: this.defaultLabel;
+			? `${this.type} ${this.context.label}`
+			: this.type;
 
 		for (const {validator, message} of this.context.validators) {
 			const result = validator(value);

--- a/source/lib/predicates/predicate.ts
+++ b/source/lib/predicates/predicate.ts
@@ -38,6 +38,8 @@ export class Predicate<T = any> implements BasePredicate<T> {
 	) {
 		this.addValidator({
 			message: value => {
+				// for base type checks, we do not include type in the label as we do for other messages,
+				// because it would be redundant with the message itself.
 				const label = this.context.label || 'argument';
 				return `Expected ${label} to be of type \`${type}\` but received type \`${is(value)}\``;
 			},

--- a/source/lib/predicates/predicate.ts
+++ b/source/lib/predicates/predicate.ts
@@ -41,7 +41,7 @@ export class Predicate<T = any> implements BasePredicate<T> {
 			message: value => {
 				// We do not include type in this label as we do for other messages, because it would be redundant.
 				const label = this.context.label || 'argument';
-				return `Expected ${label} to be of type \`${x}\` but received type \`${is(value)}\``;
+				return `Expected ${label} to be of type \`${this.type}\` but received type \`${is(value)}\``;
 			},
 			validator: value => (is as any)[x](value)
 		});

--- a/source/lib/predicates/predicate.ts
+++ b/source/lib/predicates/predicate.ts
@@ -38,8 +38,7 @@ export class Predicate<T = any> implements BasePredicate<T> {
 	) {
 		this.addValidator({
 			message: value => {
-				// for base type checks, we do not include type in the label as we do for other messages,
-				// because it would be redundant with the message itself.
+				// We do not include type in this label as we do for other messages, because it would be redundant.
 				const label = this.context.label || 'argument';
 				return `Expected ${label} to be of type \`${type}\` but received type \`${is(value)}\``;
 			},

--- a/source/lib/predicates/predicate.ts
+++ b/source/lib/predicates/predicate.ts
@@ -80,7 +80,7 @@ export class Predicate<T = any> implements BasePredicate<T> {
 	}
 
 	/**
-	 * Assigns a label to this predicate for use in error messages.
+	 * Assign a label to this predicate for use in error messages.
 	 *
 	 * @param value Label to assign.
 	 */

--- a/source/lib/predicates/set.ts
+++ b/source/lib/predicates/set.ts
@@ -8,7 +8,7 @@ export class SetPredicate<T = any> extends Predicate<Set<T>> {
 	 * @hidden
 	 */
 	constructor(context?: Context<Set<T>>) {
-		super('set', context, 'Set');
+		super('Set', context);
 	}
 
 	/**

--- a/source/lib/predicates/set.ts
+++ b/source/lib/predicates/set.ts
@@ -8,7 +8,7 @@ export class SetPredicate<T = any> extends Predicate<Set<T>> {
 	 * @hidden
 	 */
 	constructor(context?: Context<Set<T>>) {
-		super('set', context);
+		super('set', context, 'Set');
 	}
 
 	/**
@@ -18,7 +18,7 @@ export class SetPredicate<T = any> extends Predicate<Set<T>> {
 	 */
 	size(size: number) {
 		return this.addValidator({
-			message: set => `Expected Set to have size \`${size}\`, got \`${set.size}\``,
+			message: (set, label) => `Expected ${label} to have size \`${size}\`, got \`${set.size}\``,
 			validator: set => set.size === size
 		});
 	}
@@ -30,7 +30,7 @@ export class SetPredicate<T = any> extends Predicate<Set<T>> {
 	 */
 	minSize(size: number) {
 		return this.addValidator({
-			message: set => `Expected Set to have a minimum size of \`${size}\`, got \`${set.size}\``,
+			message: (set, label) => `Expected ${label} to have a minimum size of \`${size}\`, got \`${set.size}\``,
 			validator: set => set.size >= size
 		});
 	}
@@ -42,7 +42,7 @@ export class SetPredicate<T = any> extends Predicate<Set<T>> {
 	 */
 	maxSize(size: number) {
 		return this.addValidator({
-			message: set => `Expected Set to have a maximum size of \`${size}\`, got \`${set.size}\``,
+			message: (set, label) => `Expected ${label} to have a maximum size of \`${size}\`, got \`${set.size}\``,
 			validator: set => set.size <= size
 		});
 	}
@@ -54,7 +54,7 @@ export class SetPredicate<T = any> extends Predicate<Set<T>> {
 	 */
 	has(...items: T[]) {
 		return this.addValidator({
-			message: (_, missingItems) => `Expected Set to have items \`${JSON.stringify(missingItems)}\``,
+			message: (_, label, missingItems) => `Expected ${label} to have items \`${JSON.stringify(missingItems)}\``,
 			validator: set => hasItems(set, items)
 		});
 	}
@@ -66,7 +66,7 @@ export class SetPredicate<T = any> extends Predicate<Set<T>> {
 	 */
 	hasAny(...items: T[]) {
 		return this.addValidator({
-			message: () => `Expected Set to have any item of \`${JSON.stringify(items)}\``,
+			message: (_, label) => `Expected ${label} to have any item of \`${JSON.stringify(items)}\``,
 			validator: set => items.some(item => set.has(item))
 		});
 	}
@@ -78,7 +78,7 @@ export class SetPredicate<T = any> extends Predicate<Set<T>> {
 	 */
 	ofType(predicate: Predicate<T>) {
 		return this.addValidator({
-			message: (_, error) => error,
+			message: (_, label, error) => `(${label}) ${error}`,
 			validator: set => ofType(set, predicate)
 		});
 	}
@@ -88,7 +88,7 @@ export class SetPredicate<T = any> extends Predicate<Set<T>> {
 	 */
 	get empty() {
 		return this.addValidator({
-			message: set => `Expected Set to be empty, got \`${JSON.stringify(Array.from(set))}\``,
+			message: (set, label) => `Expected ${label} to be empty, got \`${JSON.stringify(Array.from(set))}\``,
 			validator: set => set.size === 0
 		});
 	}
@@ -98,7 +98,7 @@ export class SetPredicate<T = any> extends Predicate<Set<T>> {
 	 */
 	get nonEmpty() {
 		return this.addValidator({
-			message: () => 'Expected Set to not be empty',
+			message: (_, label) => `Expected ${label} to not be empty`,
 			validator: set => set.size > 0
 		});
 	}
@@ -110,7 +110,7 @@ export class SetPredicate<T = any> extends Predicate<Set<T>> {
 	 */
 	deepEqual(expected: Set<T>) {
 		return this.addValidator({
-			message: set => `Expected Set to be deeply equal to \`${JSON.stringify(Array.from(expected))}\`, got \`${JSON.stringify(Array.from(set))}\``,
+			message: (set, label) => `Expected ${label} to be deeply equal to \`${JSON.stringify(Array.from(expected))}\`, got \`${JSON.stringify(Array.from(set))}\``,
 			validator: set => isEqual(set, expected)
 		});
 	}

--- a/source/lib/predicates/string.ts
+++ b/source/lib/predicates/string.ts
@@ -16,7 +16,7 @@ export class StringPredicate extends Predicate<string> {
 	 */
 	length(length: number) {
 		return this.addValidator({
-			message: value => `Expected string to have length \`${length}\`, got \`${value}\``,
+			message: (value, label) => `Expected ${label} to have length \`${length}\`, got \`${value}\``,
 			validator: value => value.length === length
 		});
 	}
@@ -28,7 +28,7 @@ export class StringPredicate extends Predicate<string> {
 	 */
 	minLength(length: number) {
 		return this.addValidator({
-			message: value => `Expected string to have a minimum length of \`${length}\`, got \`${value}\``,
+			message: (value, label) => `Expected ${label} to have a minimum length of \`${length}\`, got \`${value}\``,
 			validator: value => value.length >= length
 		});
 	}
@@ -40,7 +40,7 @@ export class StringPredicate extends Predicate<string> {
 	 */
 	maxLength(length: number) {
 		return this.addValidator({
-			message: value => `Expected string to have a maximum length of \`${length}\`, got \`${value}\``,
+			message: (value, label) => `Expected ${label} to have a maximum length of \`${length}\`, got \`${value}\``,
 			validator: value => value.length <= length
 		});
 	}
@@ -52,7 +52,7 @@ export class StringPredicate extends Predicate<string> {
 	 */
 	matches(regExp: RegExp) {
 		return this.addValidator({
-			message: value => `Expected string to match \`${regExp}\`, got \`${value}\``,
+			message: (value, label) => `Expected ${label} to match \`${regExp}\`, got \`${value}\``,
 			validator: value => regExp.test(value)
 		});
 	}
@@ -64,7 +64,7 @@ export class StringPredicate extends Predicate<string> {
 	 */
 	startsWith(searchString: string) {
 		return this.addValidator({
-			message: value => `Expected string to start with \`${searchString}\`, got \`${value}\``,
+			message: (value, label) => `Expected ${label} to start with \`${searchString}\`, got \`${value}\``,
 			validator: value => value.startsWith(searchString)
 		});
 	}
@@ -76,7 +76,7 @@ export class StringPredicate extends Predicate<string> {
 	 */
 	endsWith(searchString: string) {
 		return this.addValidator({
-			message: value => `Expected string to end with \`${searchString}\`, got \`${value}\``,
+			message: (value, label) => `Expected ${label} to end with \`${searchString}\`, got \`${value}\``,
 			validator: value => value.endsWith(searchString)
 		});
 	}
@@ -88,7 +88,7 @@ export class StringPredicate extends Predicate<string> {
 	 */
 	includes(searchString: string) {
 		return this.addValidator({
-			message: value => `Expected string to include \`${searchString}\`, got \`${value}\``,
+			message: (value, label) => `Expected ${label} to include \`${searchString}\`, got \`${value}\``,
 			validator: value => value.includes(searchString)
 		});
 	}
@@ -98,7 +98,7 @@ export class StringPredicate extends Predicate<string> {
 	 */
 	get empty() {
 		return this.addValidator({
-			message: value => `Expected string to be empty, got \`${value}\``,
+			message: (value, label) => `Expected ${label} to be empty, got \`${value}\``,
 			validator: value => value === ''
 		});
 	}
@@ -108,7 +108,7 @@ export class StringPredicate extends Predicate<string> {
 	 */
 	get nonEmpty() {
 		return this.addValidator({
-			message: () => 'Expected string to not be empty',
+			message: (_, label) => `Expected ${label} to not be empty`,
 			validator: value => value !== ''
 		});
 	}
@@ -120,7 +120,7 @@ export class StringPredicate extends Predicate<string> {
 	 */
 	equals(expected: string) {
 		return this.addValidator({
-			message: value => `Expected string to be equal to \`${expected}\`, got \`${value}\``,
+			message: (value, label) => `Expected ${label} to be equal to \`${expected}\`, got \`${value}\``,
 			validator: value => value === expected
 		});
 	}
@@ -130,7 +130,7 @@ export class StringPredicate extends Predicate<string> {
 	 */
 	get alphanumeric() {
 		return this.addValidator({
-			message: value => `Expected string to be alphanumeric, got \`${value}\``,
+			message: (value, label) => `Expected ${label} to be alphanumeric, got \`${value}\``,
 			validator: value => /^[a-z\d]+$/i.test(value)
 		});
 	}
@@ -140,7 +140,7 @@ export class StringPredicate extends Predicate<string> {
 	 */
 	get numeric() {
 		return this.addValidator({
-			message: value => `Expected string to be numeric, got \`${value}\``,
+			message: (value, label) => `Expected ${label} to be numeric, got \`${value}\``,
 			validator: value => /^\d+$/i.test(value)
 		});
 	}
@@ -150,7 +150,7 @@ export class StringPredicate extends Predicate<string> {
 	 */
 	get date() {
 		return this.addValidator({
-			message: value => `Expected string to be a date, got \`${value}\``,
+			message: (value, label) => `Expected ${label} to be a date, got \`${value}\``,
 			validator: value => valiDate(value)
 		});
 	}

--- a/source/lib/predicates/weak-map.ts
+++ b/source/lib/predicates/weak-map.ts
@@ -6,7 +6,7 @@ export class WeakMapPredicate<T1 extends object = any, T2 = any> extends Predica
 	 * @hidden
 	 */
 	constructor(context?: Context<WeakMap<T1, T2>>) {
-		super('weakMap', context);
+		super('weakMap', context, 'WeakMap');
 	}
 
 	/**
@@ -16,7 +16,7 @@ export class WeakMapPredicate<T1 extends object = any, T2 = any> extends Predica
 	 */
 	hasKeys(...keys: T1[]) {
 		return this.addValidator({
-			message: (_, missingKeys) => `Expected WeakMap to have keys \`${JSON.stringify(missingKeys)}\``,
+			message: (_, label, missingKeys) => `Expected ${label} to have keys \`${JSON.stringify(missingKeys)}\``,
 			validator: map => hasItems(map, keys)
 		});
 	}
@@ -28,7 +28,7 @@ export class WeakMapPredicate<T1 extends object = any, T2 = any> extends Predica
 	 */
 	hasAnyKeys(...keys: T1[]) {
 		return this.addValidator({
-			message: () => `Expected WeakMap to have any key of \`${JSON.stringify(keys)}\``,
+			message: (_, label) => `Expected ${label} to have any key of \`${JSON.stringify(keys)}\``,
 			validator: map => keys.some(key => map.has(key))
 		});
 	}

--- a/source/lib/predicates/weak-map.ts
+++ b/source/lib/predicates/weak-map.ts
@@ -6,7 +6,7 @@ export class WeakMapPredicate<T1 extends object = any, T2 = any> extends Predica
 	 * @hidden
 	 */
 	constructor(context?: Context<WeakMap<T1, T2>>) {
-		super('weakMap', context, 'WeakMap');
+		super('WeakMap', context);
 	}
 
 	/**

--- a/source/lib/predicates/weak-set.ts
+++ b/source/lib/predicates/weak-set.ts
@@ -6,7 +6,7 @@ export class WeakSetPredicate<T extends object = any> extends Predicate<WeakSet<
 	 * @hidden
 	 */
 	constructor(context?: Context<WeakSet<T>>) {
-		super('weakSet', context, 'WeakSet');
+		super('WeakSet', context);
 	}
 
 	/**

--- a/source/lib/predicates/weak-set.ts
+++ b/source/lib/predicates/weak-set.ts
@@ -6,7 +6,7 @@ export class WeakSetPredicate<T extends object = any> extends Predicate<WeakSet<
 	 * @hidden
 	 */
 	constructor(context?: Context<WeakSet<T>>) {
-		super('weakSet', context);
+		super('weakSet', context, 'WeakSet');
 	}
 
 	/**
@@ -16,7 +16,7 @@ export class WeakSetPredicate<T extends object = any> extends Predicate<WeakSet<
 	 */
 	has(...items: T[]) {
 		return this.addValidator({
-			message: (_, missingItems) => `Expected WeakSet to have items \`${JSON.stringify(missingItems)}\``,
+			message: (_, label, missingItems) => `Expected ${label} to have items \`${JSON.stringify(missingItems)}\``,
 			validator: set => hasItems(set, items)
 		});
 	}
@@ -28,7 +28,7 @@ export class WeakSetPredicate<T extends object = any> extends Predicate<WeakSet<
 	 */
 	hasAny(...items: T[]) {
 		return this.addValidator({
-			message: () => `Expected WeakSet to have any item of \`${JSON.stringify(items)}\``,
+			message: (_, label) => `Expected ${label} to have any item of \`${JSON.stringify(items)}\``,
 			validator: set => items.some(item => set.has(item))
 		});
 	}

--- a/source/test/array-buffer.ts
+++ b/source/test/array-buffer.ts
@@ -4,7 +4,7 @@ import m from '..';
 test('arrayBuffer', t => {
 	t.notThrows(() => m(new ArrayBuffer(1), m.arrayBuffer));
 	t.notThrows(() => m(new ArrayBuffer(1), m.arrayBuffer.label('foo')));
-	t.throws(() => m('foo' as any, m.arrayBuffer), 'Expected argument to be of type `arrayBuffer` but received type `string`');
-	t.throws(() => m('foo' as any, m.arrayBuffer.label('foo')), 'Expected `foo` to be of type `arrayBuffer` but received type `string`');
-	t.throws(() => m(12 as any, m.arrayBuffer), 'Expected argument to be of type `arrayBuffer` but received type `number`');
+	t.throws(() => m('foo' as any, m.arrayBuffer), 'Expected argument to be of type `ArrayBuffer` but received type `string`');
+	t.throws(() => m('foo' as any, m.arrayBuffer.label('foo')), 'Expected `foo` to be of type `ArrayBuffer` but received type `string`');
+	t.throws(() => m(12 as any, m.arrayBuffer), 'Expected argument to be of type `ArrayBuffer` but received type `number`');
 });

--- a/source/test/array-buffer.ts
+++ b/source/test/array-buffer.ts
@@ -3,6 +3,8 @@ import m from '..';
 
 test('arrayBuffer', t => {
 	t.notThrows(() => m(new ArrayBuffer(1), m.arrayBuffer));
+	t.notThrows(() => m(new ArrayBuffer(1), m.arrayBuffer.label('foo')));
 	t.throws(() => m('foo' as any, m.arrayBuffer), 'Expected argument to be of type `arrayBuffer` but received type `string`');
+	t.throws(() => m('foo' as any, m.arrayBuffer.label('foo')), 'Expected `foo` to be of type `arrayBuffer` but received type `string`');
 	t.throws(() => m(12 as any, m.arrayBuffer), 'Expected argument to be of type `arrayBuffer` but received type `number`');
 });

--- a/source/test/array.ts
+++ b/source/test/array.ts
@@ -3,13 +3,19 @@ import m from '..';
 
 test('array', t => {
 	t.notThrows(() => m([], m.array));
+	t.notThrows(() => m([], m.array.label('foo')));
 	t.throws(() => m('12' as any, m.array), 'Expected argument to be of type `array` but received type `string`');
+	t.throws(() => m('12' as any, m.array.label('foo')), 'Expected `foo` to be of type `array` but received type `string`');
 });
 
 test('array.length', t => {
 	t.notThrows(() => m(['foo'], m.array.length(1)));
 	t.notThrows(() => m(['foo', 'bar'], m.array.length(2)));
+	t.notThrows(() => m(['foo', 'bar'], m.array.label('foo').length(2)));
+	t.notThrows(() => m(['foo', 'bar'], m.array.length(2).label('foo')));
 	t.throws(() => m(['foo'], m.array.length(2)), 'Expected array to have length `2`, got `1`');
+	t.throws(() => m(['foo'], m.array.label('foo').length(2)), 'Expected array `foo` to have length `2`, got `1`');
+	t.throws(() => m(['foo'], m.array.length(2).label('foo')), 'Expected array `foo` to have length `2`, got `1`');
 });
 
 test('array.minLength', t => {
@@ -65,5 +71,8 @@ test('array.deepEqual', t => {
 test('array.ofType', t => {
 	t.notThrows(() => m(['foo', 'bar'], m.array.ofType(m.string)));
 	t.notThrows(() => m(['foo', 'bar'], m.array.ofType(m.string.minLength(3))));
-	t.throws(() => m(['foo', 'b'], m.array.ofType(m.string.minLength(3))), 'Expected string to have a minimum length of `3`, got `b`');
+	t.notThrows(() => m(['foo', 'bar'], m.array.label('foo').ofType(m.string.minLength(3))));
+	t.throws(() => m(['foo', 'b'], m.array.ofType(m.string.minLength(3))), '(array) Expected string to have a minimum length of `3`, got `b`');
+	t.throws(() => m(['foo', 'b'], m.array.label('foo').ofType(m.string.minLength(3))), '(array `foo`) Expected string to have a minimum length of `3`, got `b`');
+	t.throws(() => m(['foo', 'b'], m.array.label('foo').ofType(m.string.label('bar').minLength(3))), '(array `foo`) Expected string `bar` to have a minimum length of `3`, got `b`');
 });

--- a/source/test/boolean.ts
+++ b/source/test/boolean.ts
@@ -3,21 +3,27 @@ import m from '..';
 
 test('boolean', t => {
 	t.notThrows(() => m(true, m.boolean));
+	t.notThrows(() => m(true, m.boolean.label('foo')));
 	t.throws(() => m('12' as any, m.boolean), 'Expected argument to be of type `boolean` but received type `string`');
+	t.throws(() => m('12' as any, m.boolean.label('foo')), 'Expected `foo` to be of type `boolean` but received type `string`');
 });
 
 test('boolean.true', t => {
 	t.notThrows(() => m(true, m.boolean.true));
 	t.notThrows(() => m(Boolean(true), m.boolean.true));
 	t.notThrows(() => m(Boolean(1), m.boolean.true));
-	t.throws(() => m(false, m.boolean.true), 'Expected false to be true');
-	t.throws(() => m(Boolean(0), m.boolean.true), 'Expected false to be true');
+	t.notThrows(() => m(Boolean(1), m.boolean.label('foo').true));
+	t.notThrows(() => m(Boolean(1), m.boolean.true.label('foo')));
+	t.throws(() => m(false, m.boolean.true), 'Expected boolean false to be true');
+	t.throws(() => m(false, m.boolean.label('foo').true), 'Expected boolean `foo` false to be true');
+	t.throws(() => m(false, m.boolean.true.label('foo')), 'Expected boolean `foo` false to be true');
+	t.throws(() => m(Boolean(0), m.boolean.true), 'Expected boolean false to be true');
 });
 
 test('boolean.false', t => {
 	t.notThrows(() => m(false, m.boolean.false));
 	t.notThrows(() => m(Boolean(false), m.boolean.false));
 	t.notThrows(() => m(Boolean(0), m.boolean.false));
-	t.throws(() => m(true, m.boolean.false), 'Expected true to be false');
-	t.throws(() => m(Boolean(1), m.boolean.false), 'Expected true to be false');
+	t.throws(() => m(true, m.boolean.false), 'Expected boolean true to be false');
+	t.throws(() => m(Boolean(1), m.boolean.false), 'Expected boolean true to be false');
 });

--- a/source/test/boolean.ts
+++ b/source/test/boolean.ts
@@ -14,16 +14,16 @@ test('boolean.true', t => {
 	t.notThrows(() => m(Boolean(1), m.boolean.true));
 	t.notThrows(() => m(Boolean(1), m.boolean.label('foo').true));
 	t.notThrows(() => m(Boolean(1), m.boolean.true.label('foo')));
-	t.throws(() => m(false, m.boolean.true), 'Expected boolean false to be true');
-	t.throws(() => m(false, m.boolean.label('foo').true), 'Expected boolean `foo` false to be true');
-	t.throws(() => m(false, m.boolean.true.label('foo')), 'Expected boolean `foo` false to be true');
-	t.throws(() => m(Boolean(0), m.boolean.true), 'Expected boolean false to be true');
+	t.throws(() => m(false, m.boolean.true), 'Expected boolean to be true, got false');
+	t.throws(() => m(false, m.boolean.label('foo').true), 'Expected boolean `foo` to be true, got false');
+	t.throws(() => m(false, m.boolean.true.label('foo')), 'Expected boolean `foo` to be true, got false');
+	t.throws(() => m(Boolean(0), m.boolean.true), 'Expected boolean to be true, got false');
 });
 
 test('boolean.false', t => {
 	t.notThrows(() => m(false, m.boolean.false));
 	t.notThrows(() => m(Boolean(false), m.boolean.false));
 	t.notThrows(() => m(Boolean(0), m.boolean.false));
-	t.throws(() => m(true, m.boolean.false), 'Expected boolean true to be false');
-	t.throws(() => m(Boolean(1), m.boolean.false), 'Expected boolean true to be false');
+	t.throws(() => m(true, m.boolean.false), 'Expected boolean to be false, got true');
+	t.throws(() => m(Boolean(1), m.boolean.false), 'Expected boolean to be false, got true');
 });

--- a/source/test/buffer.ts
+++ b/source/test/buffer.ts
@@ -4,6 +4,8 @@ import m from '..';
 test('buffer', t => {
 	t.notThrows(() => m(Buffer.alloc(2), m.buffer));
 	t.notThrows(() => m(Buffer.from('f'), m.buffer));
+	t.notThrows(() => m(Buffer.from('f'), m.buffer.label('foo')));
 	t.throws(() => m('foo' as any, m.buffer), 'Expected argument to be of type `buffer` but received type `string`');
+	t.throws(() => m('foo' as any, m.buffer.label('foo')), 'Expected `foo` to be of type `buffer` but received type `string`');
 	t.throws(() => m(12 as any, m.buffer), 'Expected argument to be of type `buffer` but received type `number`');
 });

--- a/source/test/buffer.ts
+++ b/source/test/buffer.ts
@@ -5,7 +5,7 @@ test('buffer', t => {
 	t.notThrows(() => m(Buffer.alloc(2), m.buffer));
 	t.notThrows(() => m(Buffer.from('f'), m.buffer));
 	t.notThrows(() => m(Buffer.from('f'), m.buffer.label('foo')));
-	t.throws(() => m('foo' as any, m.buffer), 'Expected argument to be of type `buffer` but received type `string`');
-	t.throws(() => m('foo' as any, m.buffer.label('foo')), 'Expected `foo` to be of type `buffer` but received type `string`');
-	t.throws(() => m(12 as any, m.buffer), 'Expected argument to be of type `buffer` but received type `number`');
+	t.throws(() => m('foo' as any, m.buffer), 'Expected argument to be of type `Buffer` but received type `string`');
+	t.throws(() => m('foo' as any, m.buffer.label('foo')), 'Expected `foo` to be of type `Buffer` but received type `string`');
+	t.throws(() => m(12 as any, m.buffer), 'Expected argument to be of type `Buffer` but received type `number`');
 });

--- a/source/test/data-view.ts
+++ b/source/test/data-view.ts
@@ -4,7 +4,7 @@ import m from '..';
 test('dataView', t => {
 	t.notThrows(() => m(new DataView(new ArrayBuffer(1)), m.dataView));
 	t.notThrows(() => m(new DataView(new ArrayBuffer(1)), m.dataView.label('data')));
-	t.throws(() => m(new ArrayBuffer(1) as any, m.dataView), 'Expected argument to be of type `dataView` but received type `ArrayBuffer`');
-	t.throws(() => m(new ArrayBuffer(1) as any, m.dataView.label('data')), 'Expected `data` to be of type `dataView` but received type `ArrayBuffer`');
-	t.throws(() => m(12 as any, m.dataView), 'Expected argument to be of type `dataView` but received type `number`');
+	t.throws(() => m(new ArrayBuffer(1) as any, m.dataView), 'Expected argument to be of type `DataView` but received type `ArrayBuffer`');
+	t.throws(() => m(new ArrayBuffer(1) as any, m.dataView.label('data')), 'Expected `data` to be of type `DataView` but received type `ArrayBuffer`');
+	t.throws(() => m(12 as any, m.dataView), 'Expected argument to be of type `DataView` but received type `number`');
 });

--- a/source/test/data-view.ts
+++ b/source/test/data-view.ts
@@ -3,6 +3,8 @@ import m from '..';
 
 test('dataView', t => {
 	t.notThrows(() => m(new DataView(new ArrayBuffer(1)), m.dataView));
+	t.notThrows(() => m(new DataView(new ArrayBuffer(1)), m.dataView.label('data')));
 	t.throws(() => m(new ArrayBuffer(1) as any, m.dataView), 'Expected argument to be of type `dataView` but received type `ArrayBuffer`');
+	t.throws(() => m(new ArrayBuffer(1) as any, m.dataView.label('data')), 'Expected `data` to be of type `dataView` but received type `ArrayBuffer`');
 	t.throws(() => m(12 as any, m.dataView), 'Expected argument to be of type `dataView` but received type `number`');
 });

--- a/source/test/date.ts
+++ b/source/test/date.ts
@@ -3,17 +3,23 @@ import m from '..';
 
 test('date', t => {
 	t.notThrows(() => m(new Date(), m.date));
+	t.notThrows(() => m(new Date(), m.date.label('foo')));
 	t.throws(() => m('12' as any, m.date), 'Expected argument to be of type `date` but received type `string`');
+	t.throws(() => m('12' as any, m.date.label('foo')), 'Expected `foo` to be of type `date` but received type `string`');
 });
 
 test('date.before', t => {
 	t.notThrows(() => m(new Date('2017-11-25'), m.date.before(new Date('2017-11-26'))));
 	t.notThrows(() => m(new Date('2017-11-25T12:00:00Z'), m.date.before(new Date('2017-11-25T12:00:01Z'))));
-	t.throws(() => m(new Date('2017-11-25T12:00:00Z') as any, m.date.before(new Date('2017-11-25T12:00:00Z'))), 'Expected 2017-11-25T12:00:00.000Z to be before 2017-11-25T12:00:00.000Z');
+	t.notThrows(() => m(new Date('2017-11-25T12:00:00Z'), m.date.label('foo').before(new Date('2017-11-25T12:00:01Z'))));
+	t.notThrows(() => m(new Date('2017-11-25T12:00:00Z'), m.date.before(new Date('2017-11-25T12:00:01Z')).label('foo')));
+	t.throws(() => m(new Date('2017-11-25T12:00:00Z') as any, m.date.before(new Date('2017-11-25T12:00:00Z'))), 'Expected date 2017-11-25T12:00:00.000Z to be before 2017-11-25T12:00:00.000Z');
+	t.throws(() => m(new Date('2017-11-25T12:00:00Z') as any, m.date.label('foo').before(new Date('2017-11-25T12:00:00Z'))), 'Expected date `foo` 2017-11-25T12:00:00.000Z to be before 2017-11-25T12:00:00.000Z');
+	t.throws(() => m(new Date('2017-11-25T12:00:00Z') as any, m.date.before(new Date('2017-11-25T12:00:00Z')).label('foo')), 'Expected date `foo` 2017-11-25T12:00:00.000Z to be before 2017-11-25T12:00:00.000Z');
 });
 
 test('date.after', t => {
 	t.notThrows(() => m(new Date('2017-11-26'), m.date.after(new Date('2017-11-25'))));
 	t.notThrows(() => m(new Date('2017-11-26T12:00:00Z'), m.date.after(new Date('2017-11-26T11:59:59Z'))));
-	t.throws(() => m(new Date('2017-11-26T12:00:00Z') as any, m.date.after(new Date('2017-11-26T12:00:00Z'))), 'Expected 2017-11-26T12:00:00.000Z to be after 2017-11-26T12:00:00.000Z');
+	t.throws(() => m(new Date('2017-11-26T12:00:00Z') as any, m.date.after(new Date('2017-11-26T12:00:00Z'))), 'Expected date 2017-11-26T12:00:00.000Z to be after 2017-11-26T12:00:00.000Z');
 });

--- a/source/test/error.ts
+++ b/source/test/error.ts
@@ -10,13 +10,19 @@ class CustomError extends Error {
 
 test('error', t => {
 	t.notThrows(() => m(new Error('foo'), m.error));
+	t.notThrows(() => m(new Error('foo'), m.error.label('err')));
 	t.throws(() => m('12' as any, m.error), 'Expected argument to be of type `error` but received type `string`');
+	t.throws(() => m('12' as any, m.error.label('err')), 'Expected `err` to be of type `error` but received type `string`');
 });
 
 test('error.name', t => {
 	t.notThrows(() => m(new Error('foo'), m.error.name('Error')));
 	t.notThrows(() => m(new CustomError('foo'), m.error.name('CustomError')));
+	t.notThrows(() => m(new CustomError('foo'), m.error.label('err').name('CustomError')));
+	t.notThrows(() => m(new CustomError('foo'), m.error.name('CustomError').label('err')));
 	t.throws(() => m(new CustomError('foo'), m.error.name('Error')), 'Expected error to have name `Error`, got `CustomError`');
+	t.throws(() => m(new CustomError('foo'), m.error.label('err').name('Error')), 'Expected error `err` to have name `Error`, got `CustomError`');
+	t.throws(() => m(new CustomError('foo'), m.error.name('Error').label('err')), 'Expected error `err` to have name `Error`, got `CustomError`');
 });
 
 test('error.message', t => {
@@ -48,36 +54,40 @@ test('error.instanceOf', t => {
 	t.notThrows(() => m(new CustomError('foo'), m.error.instanceOf(Error)));
 	t.notThrows(() => m(new TypeError('foo'), m.error.instanceOf(Error)));
 	t.notThrows(() => m(new Error('foo'), m.error.instanceOf(Error)));
-	t.throws(() => m(new Error('foo'), m.error.instanceOf(CustomError)), 'Expected `Error` to be of type `CustomError`');
-	t.throws(() => m(new TypeError('foo'), m.error.instanceOf(EvalError)), 'Expected `TypeError` to be of type `EvalError`');
+	t.notThrows(() => m(new Error('foo'), m.error.label('err').instanceOf(Error)));
+	t.throws(() => m(new Error('foo'), m.error.instanceOf(CustomError)), 'Expected error `Error` to be of type `CustomError`');
+	t.throws(() => m(new Error('foo'), m.error.label('err').instanceOf(CustomError)), 'Expected error `err` `Error` to be of type `CustomError`');
+	t.throws(() => m(new TypeError('foo'), m.error.instanceOf(EvalError)), 'Expected error `TypeError` to be of type `EvalError`');
+	t.throws(() => m(new TypeError('foo'), m.error.label('err').instanceOf(EvalError)), 'Expected error `err` `TypeError` to be of type `EvalError`');
 });
 
 test('error.typeError', t => {
 	t.notThrows(() => m(new TypeError('foo'), m.error.typeError));
-	t.throws(() => m(new Error('foo'), m.error.typeError), 'Expected `Error` to be of type `TypeError`');
+	t.throws(() => m(new Error('foo'), m.error.typeError), 'Expected error `Error` to be of type `TypeError`');
+	t.throws(() => m(new Error('foo'), m.error.label('foo').typeError), 'Expected error `foo` `Error` to be of type `TypeError`');
 });
 
 test('error.evalError', t => {
 	t.notThrows(() => m(new EvalError('foo'), m.error.evalError));
-	t.throws(() => m(new Error('foo'), m.error.evalError), 'Expected `Error` to be of type `EvalError`');
+	t.throws(() => m(new Error('foo'), m.error.evalError), 'Expected error `Error` to be of type `EvalError`');
 });
 
 test('error.rangeError', t => {
 	t.notThrows(() => m(new RangeError('foo'), m.error.rangeError));
-	t.throws(() => m(new EvalError('foo'), m.error.rangeError), 'Expected `EvalError` to be of type `RangeError`');
+	t.throws(() => m(new EvalError('foo'), m.error.rangeError), 'Expected error `EvalError` to be of type `RangeError`');
 });
 
 test('error.referenceError', t => {
 	t.notThrows(() => m(new ReferenceError('foo'), m.error.referenceError));
-	t.throws(() => m(new Error('foo'), m.error.referenceError), 'Expected `Error` to be of type `ReferenceError`');
+	t.throws(() => m(new Error('foo'), m.error.referenceError), 'Expected error `Error` to be of type `ReferenceError`');
 });
 
 test('error.syntaxError', t => {
 	t.notThrows(() => m(new SyntaxError('foo'), m.error.syntaxError));
-	t.throws(() => m(new Error('foo'), m.error.syntaxError), 'Expected `Error` to be of type `SyntaxError`');
+	t.throws(() => m(new Error('foo'), m.error.syntaxError), 'Expected error `Error` to be of type `SyntaxError`');
 });
 
 test('error.uriError', t => {
 	t.notThrows(() => m(new URIError('foo'), m.error.uriError));
-	t.throws(() => m(new Error('foo'), m.error.uriError), 'Expected `Error` to be of type `URIError`');
+	t.throws(() => m(new Error('foo'), m.error.uriError), 'Expected error `Error` to be of type `URIError`');
 });

--- a/source/test/function.ts
+++ b/source/test/function.ts
@@ -3,6 +3,8 @@ import m from '..';
 
 test('function', t => {
 	t.notThrows(() => m(() => {}, m.function));		// tslint:disable-line:no-empty
+	t.notThrows(() => m(() => {}, m.function.label('foo')));		// tslint:disable-line:no-empty
 	t.throws(() => m('foo' as any, m.function), 'Expected argument to be of type `function` but received type `string`');
+	t.throws(() => m('foo' as any, m.function.label('foo')), 'Expected `foo` to be of type `function` but received type `string`');
 	t.throws(() => m(12 as any, m.function), 'Expected argument to be of type `function` but received type `number`');
 });

--- a/source/test/function.ts
+++ b/source/test/function.ts
@@ -4,7 +4,7 @@ import m from '..';
 test('function', t => {
 	t.notThrows(() => m(() => {}, m.function));		// tslint:disable-line:no-empty
 	t.notThrows(() => m(() => {}, m.function.label('foo')));		// tslint:disable-line:no-empty
-	t.throws(() => m('foo' as any, m.function), 'Expected argument to be of type `function` but received type `string`');
-	t.throws(() => m('foo' as any, m.function.label('foo')), 'Expected `foo` to be of type `function` but received type `string`');
-	t.throws(() => m(12 as any, m.function), 'Expected argument to be of type `function` but received type `number`');
+	t.throws(() => m('foo' as any, m.function), 'Expected argument to be of type `Function` but received type `string`');
+	t.throws(() => m('foo' as any, m.function.label('foo')), 'Expected `foo` to be of type `Function` but received type `string`');
+	t.throws(() => m(12 as any, m.function), 'Expected argument to be of type `Function` but received type `number`');
 });

--- a/source/test/iterable.ts
+++ b/source/test/iterable.ts
@@ -6,6 +6,6 @@ test('iterable', t => {
 	t.notThrows(() => m('foo', m.iterable));
 	t.notThrows(() => m(new Map(), m.iterable));
 	t.notThrows(() => m(new Map(), m.iterable.label('foo')));
-	t.throws(() => m(12 as any, m.iterable), 'Expected argument to be of type `iterable` but received type `number`');
-	t.throws(() => m(12 as any, m.iterable.label('foo')), 'Expected `foo` to be of type `iterable` but received type `number`');
+	t.throws(() => m(12 as any, m.iterable), 'Expected argument to be of type `Iterable` but received type `number`');
+	t.throws(() => m(12 as any, m.iterable.label('foo')), 'Expected `foo` to be of type `Iterable` but received type `number`');
 });

--- a/source/test/iterable.ts
+++ b/source/test/iterable.ts
@@ -5,5 +5,7 @@ test('iterable', t => {
 	t.notThrows(() => m([], m.iterable));
 	t.notThrows(() => m('foo', m.iterable));
 	t.notThrows(() => m(new Map(), m.iterable));
+	t.notThrows(() => m(new Map(), m.iterable.label('foo')));
 	t.throws(() => m(12 as any, m.iterable), 'Expected argument to be of type `iterable` but received type `number`');
+	t.throws(() => m(12 as any, m.iterable.label('foo')), 'Expected `foo` to be of type `iterable` but received type `number`');
 });

--- a/source/test/map.ts
+++ b/source/test/map.ts
@@ -4,13 +4,19 @@ import m from '..';
 test('map', t => {
 	t.notThrows(() => m(new Map(), m.map));
 	t.notThrows(() => m(new Map([['unicorn', '🦄']]), m.map));
+	t.notThrows(() => m(new Map([['unicorn', '🦄']]), m.map.label('foo')));
 	t.throws(() => m(12 as any, m.map), 'Expected argument to be of type `map` but received type `number`');
+	t.throws(() => m(12 as any, m.map.label('foo')), 'Expected `foo` to be of type `map` but received type `number`');
 });
 
 test('map.size', t => {
 	t.notThrows(() => m(new Map(), m.map.size(0)));
 	t.notThrows(() => m(new Map([['unicorn', '🦄']]), m.map.size(1)));
+	t.notThrows(() => m(new Map([['unicorn', '🦄']]), m.map.label('foo').size(1)));
+	t.notThrows(() => m(new Map([['unicorn', '🦄']]), m.map.size(1).label('foo')));
 	t.throws(() => m(new Map([['unicorn', '🦄']]), m.map.size(0)), 'Expected Map to have size `0`, got `1`');
+	t.throws(() => m(new Map([['unicorn', '🦄']]), m.map.label('foo').size(0)), 'Expected Map `foo` to have size `0`, got `1`');
+	t.throws(() => m(new Map([['unicorn', '🦄']]), m.map.size(0).label('foo')), 'Expected Map `foo` to have size `0`, got `1`');
 });
 
 test('map.minSize', t => {
@@ -58,14 +64,20 @@ test('map.keysOfType', t => {
 	t.notThrows(() => m(new Map([['unicorn', '🦄']]), m.map.keysOfType(m.string)));
 	t.notThrows(() => m(new Map([['unicorn', '🦄'], ['rainbow', '🌈']]), m.map.keysOfType(m.string.minLength(3))));
 	t.notThrows(() => m(new Map([[1, '🦄']]), m.map.keysOfType(m.number)));
-	t.throws(() => m(new Map([['unicorn', '🦄']]), m.map.keysOfType(m.number)), 'Expected argument to be of type `number` but received type `string`');
+	t.notThrows(() => m(new Map([[1, '🦄']]), m.map.label('foo').keysOfType(m.number)));
+	t.throws(() => m(new Map([['unicorn', '🦄']]), m.map.keysOfType(m.number)), '(Map) Expected argument to be of type `number` but received type `string`');
+	t.throws(() => m(new Map([['unicorn', '🦄']]), m.map.label('foo').keysOfType(m.number)), '(Map `foo`) Expected argument to be of type `number` but received type `string`');
+	t.throws(() => m(new Map([['unicorn', '🦄']]), m.map.label('foo').keysOfType(m.number.label('bar'))), '(Map `foo`) Expected `bar` to be of type `number` but received type `string`');
 });
 
 test('map.valuesOfType', t => {
 	t.notThrows(() => m(new Map([['unicorn', 1]]), m.map.valuesOfType(m.number)));
 	t.notThrows(() => m(new Map([['unicorn', 10], ['rainbow', 11]]), m.map.valuesOfType(m.number.greaterThanOrEqual(10))));
 	t.notThrows(() => m(new Map([['unicorn', '🦄']]), m.map.valuesOfType(m.string)));
-	t.throws(() => m(new Map([['unicorn', '🦄']]), m.map.valuesOfType(m.number)), 'Expected argument to be of type `number` but received type `string`');
+	t.notThrows(() => m(new Map([['unicorn', '🦄']]), m.map.label('foo').valuesOfType(m.string)));
+	t.throws(() => m(new Map([['unicorn', '🦄']]), m.map.valuesOfType(m.number)), '(Map) Expected argument to be of type `number` but received type `string`');
+	t.throws(() => m(new Map([['unicorn', '🦄']]), m.map.label('foo').valuesOfType(m.number)), '(Map `foo`) Expected argument to be of type `number` but received type `string`');
+	t.throws(() => m(new Map([['unicorn', '🦄']]), m.map.label('foo').valuesOfType(m.number.label('bar'))), '(Map `foo`) Expected `bar` to be of type `number` but received type `string`');
 });
 
 test('map.empty', t => {

--- a/source/test/map.ts
+++ b/source/test/map.ts
@@ -5,8 +5,8 @@ test('map', t => {
 	t.notThrows(() => m(new Map(), m.map));
 	t.notThrows(() => m(new Map([['unicorn', '🦄']]), m.map));
 	t.notThrows(() => m(new Map([['unicorn', '🦄']]), m.map.label('foo')));
-	t.throws(() => m(12 as any, m.map), 'Expected argument to be of type `map` but received type `number`');
-	t.throws(() => m(12 as any, m.map.label('foo')), 'Expected `foo` to be of type `map` but received type `number`');
+	t.throws(() => m(12 as any, m.map), 'Expected argument to be of type `Map` but received type `number`');
+	t.throws(() => m(12 as any, m.map.label('foo')), 'Expected `foo` to be of type `Map` but received type `number`');
 });
 
 test('map.size', t => {

--- a/source/test/nan.ts
+++ b/source/test/nan.ts
@@ -5,6 +5,8 @@ test('nan', t => {
 	t.notThrows(() => m(NaN, m.nan));
 	t.notThrows(() => m(Number.NaN, m.nan));
 	t.notThrows(() => m(0 / 0, m.nan));
+	t.notThrows(() => m(0 / 0, m.nan.label('foo')));
 	t.throws(() => m(12, m.nan), 'Expected argument to be of type `nan` but received type `number`');
+	t.throws(() => m(12, m.nan.label('foo')), 'Expected `foo` to be of type `nan` but received type `number`');
 	t.throws(() => m('12' as any, m.nan), 'Expected argument to be of type `nan` but received type `string`');
 });

--- a/source/test/null-or-undefined.ts
+++ b/source/test/null-or-undefined.ts
@@ -9,5 +9,7 @@ test('nullOrUndefined', t => {
 	t.notThrows(() => m(undefined, m.nullOrUndefined));
 	t.notThrows(() => m(x, m.nullOrUndefined));
 	t.notThrows(() => m(y, m.nullOrUndefined));
+	t.notThrows(() => m(y, m.nullOrUndefined.label('foo')));
 	t.throws(() => m('foo', m.nullOrUndefined), 'Expected argument to be of type `nullOrUndefined` but received type `string`');
+	t.throws(() => m('foo', m.nullOrUndefined.label('foo')), 'Expected `foo` to be of type `nullOrUndefined` but received type `string`');
 });

--- a/source/test/null.ts
+++ b/source/test/null.ts
@@ -6,6 +6,8 @@ test('null', t => {
 
 	t.notThrows(() => m(null, m.null));
 	t.notThrows(() => m(x, m.null));
+	t.notThrows(() => m(x, m.null.label('foo')));
 	t.throws(() => m(undefined, m.null), 'Expected argument to be of type `null` but received type `undefined`');
+	t.throws(() => m(undefined, m.null.label('foo')), 'Expected `foo` to be of type `null` but received type `undefined`');
 	t.throws(() => m('foo', m.null), 'Expected argument to be of type `null` but received type `string`');
 });

--- a/source/test/number.ts
+++ b/source/test/number.ts
@@ -3,73 +3,79 @@ import m from '..';
 
 test('number', t => {
 	t.notThrows(() => m(1, m.number));
+	t.notThrows(() => m(1, m.number.label('foo')));
 	t.throws(() => m('12' as any, m.number), 'Expected argument to be of type `number` but received type `string`');
+	t.throws(() => m('12' as any, m.number.label('foo')), 'Expected `foo` to be of type `number` but received type `string`');
 });
 
 test('number.inRange', t => {
 	t.notThrows(() => m(10, m.number.inRange(0, 20)));
 	t.notThrows(() => m(10, m.number.inRange(10, 20)));
 	t.notThrows(() => m(10, m.number.inRange(0, 10)));
-	t.throws(() => m(10 as any, m.number.inRange(0, 9)), 'Expected 10 to be in range [0..9]');
-	t.throws(() => m(10 as any, m.number.inRange(11, 20)), 'Expected 10 to be in range [11..20]');
+	t.notThrows(() => m(10, m.number.label('foo').inRange(0, 10)));
+	t.notThrows(() => m(10, m.number.inRange(0, 10).label('foo')));
+	t.throws(() => m(10 as any, m.number.inRange(0, 9)), 'Expected number 10 to be in range [0..9]');
+	t.throws(() => m(10 as any, m.number.label('foo').inRange(0, 9)), 'Expected number `foo` 10 to be in range [0..9]');
+	t.throws(() => m(10 as any, m.number.inRange(0, 9).label('foo')), 'Expected number `foo` 10 to be in range [0..9]');
+	t.throws(() => m(10 as any, m.number.inRange(11, 20)), 'Expected number 10 to be in range [11..20]');
 });
 
 test('number.greaterThan', t => {
 	t.notThrows(() => m(10, m.number.greaterThan(5)));
 	t.notThrows(() => m(10, m.number.greaterThan(9)));
-	t.throws(() => m(10 as any, m.number.greaterThan(10)), 'Expected 10 to be greater than 10');
-	t.throws(() => m(10 as any, m.number.greaterThan(11)), 'Expected 10 to be greater than 11');
-	t.throws(() => m(10 as any, m.number.greaterThan(20)), 'Expected 10 to be greater than 20');
+	t.throws(() => m(10 as any, m.number.greaterThan(10)), 'Expected number 10 to be greater than 10');
+	t.throws(() => m(10 as any, m.number.greaterThan(11)), 'Expected number 10 to be greater than 11');
+	t.throws(() => m(10 as any, m.number.greaterThan(20)), 'Expected number 10 to be greater than 20');
 });
 
 test('number.greaterThanOrEqual', t => {
 	t.notThrows(() => m(10, m.number.greaterThanOrEqual(5)));
 	t.notThrows(() => m(10, m.number.greaterThanOrEqual(10)));
-	t.throws(() => m(10 as any, m.number.greaterThanOrEqual(11)), 'Expected 10 to be greater than or equal to 11');
-	t.throws(() => m(10 as any, m.number.greaterThanOrEqual(20)), 'Expected 10 to be greater than or equal to 20');
+	t.throws(() => m(10 as any, m.number.greaterThanOrEqual(11)), 'Expected number 10 to be greater than or equal to 11');
+	t.throws(() => m(10 as any, m.number.greaterThanOrEqual(20)), 'Expected number 10 to be greater than or equal to 20');
 });
 
 test('number.lessThan', t => {
 	t.notThrows(() => m(10, m.number.lessThan(20)));
 	t.notThrows(() => m(10, m.number.lessThan(11)));
-	t.throws(() => m(10 as any, m.number.lessThan(10)), 'Expected 10 to be less than 10');
-	t.throws(() => m(10 as any, m.number.lessThan(9)), 'Expected 10 to be less than 9');
-	t.throws(() => m(10 as any, m.number.lessThan(0)), 'Expected 10 to be less than 0');
+	t.throws(() => m(10 as any, m.number.lessThan(10)), 'Expected number 10 to be less than 10');
+	t.throws(() => m(10 as any, m.number.lessThan(9)), 'Expected number 10 to be less than 9');
+	t.throws(() => m(10 as any, m.number.lessThan(0)), 'Expected number 10 to be less than 0');
 });
 
 test('number.lessThanOrEqual', t => {
 	t.notThrows(() => m(10, m.number.lessThanOrEqual(20)));
 	t.notThrows(() => m(10, m.number.lessThanOrEqual(10)));
-	t.throws(() => m(10 as any, m.number.lessThanOrEqual(9)), 'Expected 10 to be less than or equal to 9');
-	t.throws(() => m(10 as any, m.number.lessThanOrEqual(0)), 'Expected 10 to be less than or equal to 0');
+	t.throws(() => m(10 as any, m.number.lessThanOrEqual(9)), 'Expected number 10 to be less than or equal to 9');
+	t.throws(() => m(10 as any, m.number.lessThanOrEqual(0)), 'Expected number 10 to be less than or equal to 0');
 });
 
 test('number.equal', t => {
 	t.notThrows(() => m(10, m.number.equal(10)));
-	t.throws(() => m(10 as any, m.number.equal(5)), 'Expected 10 to be equal to 5');
+	t.throws(() => m(10 as any, m.number.equal(5)), 'Expected number 10 to be equal to 5');
 });
 
 test('number.integer', t => {
 	t.notThrows(() => m(10, m.number.integer));
-	t.throws(() => m(10.1 as any, m.number.integer), 'Expected 10.1 to be an integer');
+	t.throws(() => m(10.1 as any, m.number.integer), 'Expected number 10.1 to be an integer');
 });
 
 test('number.finite', t => {
 	t.notThrows(() => m(10, m.number.finite));
-	t.throws(() => m(Infinity as any, m.number.finite), 'Expected Infinity to be finite');
+	t.throws(() => m(Infinity as any, m.number.finite), 'Expected number Infinity to be finite');
 });
 
 test('number.infinite', t => {
 	t.notThrows(() => m(Infinity, m.number.infinite));
-	t.throws(() => m(10 as any, m.number.infinite), 'Expected 10 to be infinite');
+	t.throws(() => m(10 as any, m.number.infinite), 'Expected number 10 to be infinite');
 });
 
 test('number.positive', t => {
 	t.notThrows(() => m(1, m.number.positive));
-	t.throws(() => m(-1 as any, m.number.positive), 'Expected -1 to be positive');
+	t.throws(() => m(-1 as any, m.number.positive), 'Expected number -1 to be positive');
 });
 
 test('number.negative', t => {
 	t.notThrows(() => m(-1, m.number.negative));
-	t.throws(() => m(1 as any, m.number.negative), 'Expected 1 to be negative');
+	t.throws(() => m(1 as any, m.number.negative), 'Expected number 1 to be negative');
 });

--- a/source/test/number.ts
+++ b/source/test/number.ts
@@ -14,68 +14,68 @@ test('number.inRange', t => {
 	t.notThrows(() => m(10, m.number.inRange(0, 10)));
 	t.notThrows(() => m(10, m.number.label('foo').inRange(0, 10)));
 	t.notThrows(() => m(10, m.number.inRange(0, 10).label('foo')));
-	t.throws(() => m(10 as any, m.number.inRange(0, 9)), 'Expected number 10 to be in range [0..9]');
-	t.throws(() => m(10 as any, m.number.label('foo').inRange(0, 9)), 'Expected number `foo` 10 to be in range [0..9]');
-	t.throws(() => m(10 as any, m.number.inRange(0, 9).label('foo')), 'Expected number `foo` 10 to be in range [0..9]');
-	t.throws(() => m(10 as any, m.number.inRange(11, 20)), 'Expected number 10 to be in range [11..20]');
+	t.throws(() => m(10 as any, m.number.inRange(0, 9)), 'Expected number to be in range [0..9], got 10');
+	t.throws(() => m(10 as any, m.number.label('foo').inRange(0, 9)), 'Expected number `foo` to be in range [0..9], got 10');
+	t.throws(() => m(10 as any, m.number.inRange(0, 9).label('foo')), 'Expected number `foo` to be in range [0..9], got 10');
+	t.throws(() => m(10 as any, m.number.inRange(11, 20)), 'Expected number to be in range [11..20], got 10');
 });
 
 test('number.greaterThan', t => {
 	t.notThrows(() => m(10, m.number.greaterThan(5)));
 	t.notThrows(() => m(10, m.number.greaterThan(9)));
-	t.throws(() => m(10 as any, m.number.greaterThan(10)), 'Expected number 10 to be greater than 10');
-	t.throws(() => m(10 as any, m.number.greaterThan(11)), 'Expected number 10 to be greater than 11');
-	t.throws(() => m(10 as any, m.number.greaterThan(20)), 'Expected number 10 to be greater than 20');
+	t.throws(() => m(10 as any, m.number.greaterThan(10)), 'Expected number to be greater than 10, got 10');
+	t.throws(() => m(10 as any, m.number.greaterThan(11)), 'Expected number to be greater than 11, got 10');
+	t.throws(() => m(10 as any, m.number.greaterThan(20)), 'Expected number to be greater than 20, got 10');
 });
 
 test('number.greaterThanOrEqual', t => {
 	t.notThrows(() => m(10, m.number.greaterThanOrEqual(5)));
 	t.notThrows(() => m(10, m.number.greaterThanOrEqual(10)));
-	t.throws(() => m(10 as any, m.number.greaterThanOrEqual(11)), 'Expected number 10 to be greater than or equal to 11');
-	t.throws(() => m(10 as any, m.number.greaterThanOrEqual(20)), 'Expected number 10 to be greater than or equal to 20');
+	t.throws(() => m(10 as any, m.number.greaterThanOrEqual(11)), 'Expected number to be greater than or equal to 11, got 10');
+	t.throws(() => m(10 as any, m.number.greaterThanOrEqual(20)), 'Expected number to be greater than or equal to 20, got 10');
 });
 
 test('number.lessThan', t => {
 	t.notThrows(() => m(10, m.number.lessThan(20)));
 	t.notThrows(() => m(10, m.number.lessThan(11)));
-	t.throws(() => m(10 as any, m.number.lessThan(10)), 'Expected number 10 to be less than 10');
-	t.throws(() => m(10 as any, m.number.lessThan(9)), 'Expected number 10 to be less than 9');
-	t.throws(() => m(10 as any, m.number.lessThan(0)), 'Expected number 10 to be less than 0');
+	t.throws(() => m(10 as any, m.number.lessThan(10)), 'Expected number to be less than 10, got 10');
+	t.throws(() => m(10 as any, m.number.lessThan(9)), 'Expected number to be less than 9, got 10');
+	t.throws(() => m(10 as any, m.number.lessThan(0)), 'Expected number to be less than 0, got 10');
 });
 
 test('number.lessThanOrEqual', t => {
 	t.notThrows(() => m(10, m.number.lessThanOrEqual(20)));
 	t.notThrows(() => m(10, m.number.lessThanOrEqual(10)));
-	t.throws(() => m(10 as any, m.number.lessThanOrEqual(9)), 'Expected number 10 to be less than or equal to 9');
-	t.throws(() => m(10 as any, m.number.lessThanOrEqual(0)), 'Expected number 10 to be less than or equal to 0');
+	t.throws(() => m(10 as any, m.number.lessThanOrEqual(9)), 'Expected number to be less than or equal to 9, got 10');
+	t.throws(() => m(10 as any, m.number.lessThanOrEqual(0)), 'Expected number to be less than or equal to 0, got 10');
 });
 
 test('number.equal', t => {
 	t.notThrows(() => m(10, m.number.equal(10)));
-	t.throws(() => m(10 as any, m.number.equal(5)), 'Expected number 10 to be equal to 5');
+	t.throws(() => m(10 as any, m.number.equal(5)), 'Expected number to be equal to 5, got 10');
 });
 
 test('number.integer', t => {
 	t.notThrows(() => m(10, m.number.integer));
-	t.throws(() => m(10.1 as any, m.number.integer), 'Expected number 10.1 to be an integer');
+	t.throws(() => m(10.1 as any, m.number.integer), 'Expected number to be an integer, got 10.1');
 });
 
 test('number.finite', t => {
 	t.notThrows(() => m(10, m.number.finite));
-	t.throws(() => m(Infinity as any, m.number.finite), 'Expected number Infinity to be finite');
+	t.throws(() => m(Infinity as any, m.number.finite), 'Expected number to be finite, got Infinity');
 });
 
 test('number.infinite', t => {
 	t.notThrows(() => m(Infinity, m.number.infinite));
-	t.throws(() => m(10 as any, m.number.infinite), 'Expected number 10 to be infinite');
+	t.throws(() => m(10 as any, m.number.infinite), 'Expected number to be infinite, got 10');
 });
 
 test('number.positive', t => {
 	t.notThrows(() => m(1, m.number.positive));
-	t.throws(() => m(-1 as any, m.number.positive), 'Expected number -1 to be positive');
+	t.throws(() => m(-1 as any, m.number.positive), 'Expected number to be positive, got -1');
 });
 
 test('number.negative', t => {
 	t.notThrows(() => m(-1, m.number.negative));
-	t.throws(() => m(1 as any, m.number.negative), 'Expected number 1 to be negative');
+	t.throws(() => m(1 as any, m.number.negative), 'Expected number to be negative, got 1');
 });

--- a/source/test/object.ts
+++ b/source/test/object.ts
@@ -5,14 +5,20 @@ class Unicorn {}			// tslint:disable-line
 
 test('object', t => {
 	t.notThrows(() => m({}, m.object));
+	t.notThrows(() => m({}, m.object.label('foo')));
 	t.notThrows(() => m(new Error('foo'), m.object));
 	t.throws(() => m('foo' as any, m.object), 'Expected argument to be of type `object` but received type `string`');
+	t.throws(() => m('foo' as any, m.object.label('foo')), 'Expected `foo` to be of type `object` but received type `string`');
 	t.throws(() => m(1 as any, m.object), 'Expected argument to be of type `object` but received type `number`');
 });
 
 test('object.plain', t => {
 	t.notThrows(() => m({}, m.object.plain));
+	t.notThrows(() => m({}, m.object.label('foo').plain));
+	t.notThrows(() => m({}, m.object.plain.label('foo')));
 	t.throws(() => m(new Error('foo'), m.object.plain), 'Expected object to be a plain object');
+	t.throws(() => m(new Error('foo'), m.object.label('foo').plain), 'Expected object `foo` to be a plain object');
+	t.throws(() => m(new Error('foo'), m.object.plain.label('foo')), 'Expected object `foo` to be a plain object');
 });
 
 test('object.empty', t => {
@@ -29,8 +35,11 @@ test('object.valuesOfType', t => {
 	t.notThrows(() => m({unicorn: '🦄'}, m.object.valuesOfType(m.string)));
 	t.notThrows(() => m({unicorn: '🦄', rainbow: '🌈'}, m.object.valuesOfType(m.string)));
 	t.notThrows(() => m({unicorn: 1, rainbow: 2}, m.object.valuesOfType(m.number)));
-	t.throws(() => m({unicorn: '🦄', rainbow: 2}, m.object.valuesOfType(m.string)), 'Expected argument to be of type `string` but received type `number`');
-	t.throws(() => m({unicorn: 'a', rainbow: 'b'}, m.object.valuesOfType(m.string.minLength(2))), 'Expected string to have a minimum length of `2`, got `a`');
+	t.notThrows(() => m({unicorn: 1, rainbow: 2}, m.object.label('foo').valuesOfType(m.number)));
+	t.throws(() => m({unicorn: '🦄', rainbow: 2}, m.object.valuesOfType(m.string)), '(object) Expected argument to be of type `string` but received type `number`');
+	t.throws(() => m({unicorn: '🦄', rainbow: 2}, m.object.label('foo').valuesOfType(m.string)), '(object `foo`) Expected argument to be of type `string` but received type `number`');
+	t.throws(() => m({unicorn: '🦄', rainbow: 2}, m.object.label('foo').valuesOfType(m.string.label('bar'))), '(object `foo`) Expected `bar` to be of type `string` but received type `number`');
+	t.throws(() => m({unicorn: 'a', rainbow: 'b'}, m.object.valuesOfType(m.string.minLength(2))), '(object) Expected string to have a minimum length of `2`, got `a`');
 });
 
 test('object.valuesOfTypeDeep', t => {
@@ -38,8 +47,11 @@ test('object.valuesOfTypeDeep', t => {
 	t.notThrows(() => m({unicorn: '🦄', rainbow: '🌈'}, m.object.deepValuesOfType(m.string)));
 	t.notThrows(() => m({unicorn: {key: '🦄', value: '🌈'}}, m.object.deepValuesOfType(m.string)));
 	t.notThrows(() => m({a: {b: {c: {d: 1}, e: 2}, f: 3}}, m.object.deepValuesOfType(m.number)));
-	t.throws(() => m({unicorn: {key: '🦄', value: 1}}, m.object.deepValuesOfType(m.string)), 'Expected argument to be of type `string` but received type `number`');
-	t.throws(() => m({a: {b: {c: {d: 1}, e: '2'}, f: 3}}, m.object.deepValuesOfType(m.number)), 'Expected argument to be of type `number` but received type `string`');
+	t.notThrows(() => m({a: {b: {c: {d: 1}, e: 2}, f: 3}}, m.object.label('foo').deepValuesOfType(m.number)));
+	t.throws(() => m({unicorn: {key: '🦄', value: 1}}, m.object.deepValuesOfType(m.string)), '(object) Expected argument to be of type `string` but received type `number`');
+	t.throws(() => m({unicorn: {key: '🦄', value: 1}}, m.object.label('foo').deepValuesOfType(m.string)), '(object `foo`) Expected argument to be of type `string` but received type `number`');
+	t.throws(() => m({unicorn: {key: '🦄', value: 1}}, m.object.label('foo').deepValuesOfType(m.string.label('bar'))), '(object `foo`) Expected `bar` to be of type `string` but received type `number`');
+	t.throws(() => m({a: {b: {c: {d: 1}, e: '2'}, f: 3}}, m.object.deepValuesOfType(m.number)), '(object) Expected argument to be of type `number` but received type `string`');
 });
 
 test('object.deepEqual', t => {
@@ -51,9 +63,10 @@ test('object.deepEqual', t => {
 test('object.instanceOf', t => {
 	t.notThrows(() => m(new Error('🦄'), m.object.instanceOf(Error)));
 	t.notThrows(() => m(new Unicorn(), m.object.instanceOf(Unicorn)));
-	t.throws(() => m(new Unicorn(), m.object.instanceOf(Error)), 'Expected `Unicorn` to be of type `Error`');
-	t.throws(() => m(new Error('🦄'), m.object.instanceOf(Unicorn)), 'Expected `Error` to be of type `Unicorn`');
-	t.throws(() => m({unicorn: '🦄'}, m.object.instanceOf(Unicorn)), 'Expected `{"unicorn":"🦄"}` to be of type `Unicorn`');
+	t.throws(() => m(new Unicorn(), m.object.instanceOf(Error)), 'Expected object `Unicorn` to be of type `Error`');
+	t.throws(() => m(new Unicorn(), m.object.label('foo').instanceOf(Error)), 'Expected object `foo` `Unicorn` to be of type `Error`');
+	t.throws(() => m(new Error('🦄'), m.object.instanceOf(Unicorn)), 'Expected object `Error` to be of type `Unicorn`');
+	t.throws(() => m({unicorn: '🦄'}, m.object.instanceOf(Unicorn)), 'Expected object `{"unicorn":"🦄"}` to be of type `Unicorn`');
 });
 
 test('object.hasKeys', t => {

--- a/source/test/promise.ts
+++ b/source/test/promise.ts
@@ -4,6 +4,8 @@ import m from '..';
 test('promise', t => {
 	t.notThrows(() => m(Promise.resolve(), m.promise));
 	t.notThrows(() => m(new Promise(resolve => resolve()), m.promise));
+	t.notThrows(() => m(new Promise(resolve => resolve()), m.promise.label('foo')));
 	t.throws(() => m('foo' as any, m.promise), 'Expected argument to be of type `promise` but received type `string`');
+	t.throws(() => m('foo' as any, m.promise.label('foo')), 'Expected `foo` to be of type `promise` but received type `string`');
 	t.throws(() => m(12 as any, m.promise), 'Expected argument to be of type `promise` but received type `number`');
 });

--- a/source/test/promise.ts
+++ b/source/test/promise.ts
@@ -5,7 +5,7 @@ test('promise', t => {
 	t.notThrows(() => m(Promise.resolve(), m.promise));
 	t.notThrows(() => m(new Promise(resolve => resolve()), m.promise));
 	t.notThrows(() => m(new Promise(resolve => resolve()), m.promise.label('foo')));
-	t.throws(() => m('foo' as any, m.promise), 'Expected argument to be of type `promise` but received type `string`');
-	t.throws(() => m('foo' as any, m.promise.label('foo')), 'Expected `foo` to be of type `promise` but received type `string`');
-	t.throws(() => m(12 as any, m.promise), 'Expected argument to be of type `promise` but received type `number`');
+	t.throws(() => m('foo' as any, m.promise), 'Expected argument to be of type `Promise` but received type `string`');
+	t.throws(() => m('foo' as any, m.promise.label('foo')), 'Expected `foo` to be of type `Promise` but received type `string`');
+	t.throws(() => m(12 as any, m.promise), 'Expected argument to be of type `Promise` but received type `number`');
 });

--- a/source/test/regexp.ts
+++ b/source/test/regexp.ts
@@ -4,6 +4,8 @@ import m from '..';
 test('regExp', t => {
 	t.notThrows(() => m(/\d/, m.regExp));
 	t.notThrows(() => m(new RegExp('\d'), m.regExp));
+	t.notThrows(() => m(new RegExp('\d'), m.regExp.label('foo')));
 	t.throws(() => m('foo' as any, m.regExp), 'Expected argument to be of type `regExp` but received type `string`');
+	t.throws(() => m('foo' as any, m.regExp.label('foo')), 'Expected `foo` to be of type `regExp` but received type `string`');
 	t.throws(() => m(12 as any, m.regExp), 'Expected argument to be of type `regExp` but received type `number`');
 });

--- a/source/test/regexp.ts
+++ b/source/test/regexp.ts
@@ -5,7 +5,7 @@ test('regExp', t => {
 	t.notThrows(() => m(/\d/, m.regExp));
 	t.notThrows(() => m(new RegExp('\d'), m.regExp));
 	t.notThrows(() => m(new RegExp('\d'), m.regExp.label('foo')));
-	t.throws(() => m('foo' as any, m.regExp), 'Expected argument to be of type `regExp` but received type `string`');
-	t.throws(() => m('foo' as any, m.regExp.label('foo')), 'Expected `foo` to be of type `regExp` but received type `string`');
-	t.throws(() => m(12 as any, m.regExp), 'Expected argument to be of type `regExp` but received type `number`');
+	t.throws(() => m('foo' as any, m.regExp), 'Expected argument to be of type `RegExp` but received type `string`');
+	t.throws(() => m('foo' as any, m.regExp.label('foo')), 'Expected `foo` to be of type `RegExp` but received type `string`');
+	t.throws(() => m(12 as any, m.regExp), 'Expected argument to be of type `RegExp` but received type `number`');
 });

--- a/source/test/set.ts
+++ b/source/test/set.ts
@@ -5,8 +5,8 @@ test('set', t => {
 	t.notThrows(() => m(new Set(), m.set));
 	t.notThrows(() => m(new Set(['🦄']), m.set));
 	t.notThrows(() => m(new Set(['🦄']), m.set.label('foo')));
-	t.throws(() => m(12 as any, m.set), 'Expected argument to be of type `set` but received type `number`');
-	t.throws(() => m(12 as any, m.set.label('foo')), 'Expected `foo` to be of type `set` but received type `number`');
+	t.throws(() => m(12 as any, m.set), 'Expected argument to be of type `Set` but received type `number`');
+	t.throws(() => m(12 as any, m.set.label('foo')), 'Expected `foo` to be of type `Set` but received type `number`');
 });
 
 test('set.size', t => {

--- a/source/test/set.ts
+++ b/source/test/set.ts
@@ -4,13 +4,19 @@ import m from '..';
 test('set', t => {
 	t.notThrows(() => m(new Set(), m.set));
 	t.notThrows(() => m(new Set(['🦄']), m.set));
+	t.notThrows(() => m(new Set(['🦄']), m.set.label('foo')));
 	t.throws(() => m(12 as any, m.set), 'Expected argument to be of type `set` but received type `number`');
+	t.throws(() => m(12 as any, m.set.label('foo')), 'Expected `foo` to be of type `set` but received type `number`');
 });
 
 test('set.size', t => {
 	t.notThrows(() => m(new Set(), m.set.size(0)));
 	t.notThrows(() => m(new Set(['🦄']), m.set.size(1)));
+	t.notThrows(() => m(new Set(['🦄']), m.set.label('foo').size(1)));
+	t.notThrows(() => m(new Set(['🦄']), m.set.size(1).label('foo')));
 	t.throws(() => m(new Set(['🦄']), m.set.size(0)), 'Expected Set to have size `0`, got `1`');
+	t.throws(() => m(new Set(['🦄']), m.set.label('foo').size(0)), 'Expected Set `foo` to have size `0`, got `1`');
+	t.throws(() => m(new Set(['🦄']), m.set.size(0).label('foo')), 'Expected Set `foo` to have size `0`, got `1`');
 });
 
 test('set.minSize', t => {
@@ -45,7 +51,10 @@ test('set.ofType', t => {
 	t.notThrows(() => m(new Set(['unicorn']), m.set.ofType(m.string)));
 	t.notThrows(() => m(new Set(['unicorn', 'rainbow']), m.set.ofType(m.string.minLength(3))));
 	t.notThrows(() => m(new Set([1]), m.set.ofType(m.number)));
-	t.throws(() => m(new Set(['unicorn']), m.set.ofType(m.number)), 'Expected argument to be of type `number` but received type `string`');
+	t.notThrows(() => m(new Set([1]), m.set.label('foo').ofType(m.number)));
+	t.throws(() => m(new Set(['unicorn']), m.set.ofType(m.number)), '(Set) Expected argument to be of type `number` but received type `string`');
+	t.throws(() => m(new Set(['unicorn']), m.set.label('foo').ofType(m.number)), '(Set `foo`) Expected argument to be of type `number` but received type `string`');
+	t.throws(() => m(new Set(['unicorn']), m.set.label('foo').ofType(m.number.label('bar'))), '(Set `foo`) Expected `bar` to be of type `number` but received type `string`');
 });
 
 test('set.empty', t => {

--- a/source/test/string.ts
+++ b/source/test/string.ts
@@ -3,13 +3,19 @@ import m from '..';
 
 test('string', t => {
 	t.notThrows(() => m('foo', m.string));
+	t.notThrows(() => m('foo', m.string.label('foo')));
 	t.throws(() => m(12 as any, m.string), 'Expected argument to be of type `string` but received type `number`');
+	t.throws(() => m(12 as any, m.string.label('bar')), 'Expected `bar` to be of type `string` but received type `number`');
 });
 
 test('string.length', t => {
 	t.notThrows(() => m('foo', m.string.length(3)));
 	t.notThrows(() => m('foobar', m.string.length(6)));
+	t.notThrows(() => m('bar', m.string.label('bar').length(3)));
+	t.notThrows(() => m('bar', m.string.length(3).label('bar')));
 	t.throws(() => m('foo' as any, m.string.length(4)), 'Expected string to have length `4`, got `foo`');
+	t.throws(() => m('foo' as any, m.string.label('foo').length(4)), 'Expected string `foo` to have length `4`, got `foo`');
+	t.throws(() => m('foo' as any, m.string.length(4).label('foo')), 'Expected string `foo` to have length `4`, got `foo`');
 });
 
 test('string.minLength', t => {
@@ -78,5 +84,7 @@ test('string.numeric', t => {
 test('string.date', t => {
 	t.notThrows(() => m('2017-03-02', m.string.date));
 	t.notThrows(() => m('2017-03-02T10:00:00Z', m.string.date));
+	t.notThrows(() => m('2017-03-02T10:00:00Z', m.string.label('bar').date));
 	t.throws(() => m('foo' as any, m.string.date), 'Expected string to be a date, got `foo`');
+	t.throws(() => m('foo' as any, m.string.label('bar').date), 'Expected string `bar` to be a date, got `foo`');
 });

--- a/source/test/symbol.ts
+++ b/source/test/symbol.ts
@@ -4,5 +4,7 @@ import m from '..';
 test('symbol', t => {
 	t.notThrows(() => m(Symbol.iterator, m.symbol));
 	t.notThrows(() => m(Symbol('foo'), m.symbol));
+	t.notThrows(() => m(Symbol('foo'), m.symbol.label('foo')));
 	t.throws(() => m(12 as any, m.symbol), 'Expected argument to be of type `symbol` but received type `number`');
+	t.throws(() => m(12 as any, m.symbol.label('foo')), 'Expected `foo` to be of type `symbol` but received type `number`');
 });

--- a/source/test/test.ts
+++ b/source/test/test.ts
@@ -5,7 +5,12 @@ test('not', t => {
 	t.notThrows(() => m(1, m.number.not.infinite));
 	t.notThrows(() => m(1, m.number.not.infinite.greaterThan(5)));
 	t.notThrows(() => m('foo!', m.string.not.alphanumeric));
+	t.notThrows(() => m('foo!', m.string.not.alphanumeric));
+	t.notThrows(() => m('foo!', m.string.label('foo').not.alphanumeric));
+	t.notThrows(() => m('foo!', m.string.not.label('foo').alphanumeric));
+	t.notThrows(() => m('foo!', m.string.not.alphanumeric.label('foo')));
 	t.throws(() => m('', m.string.not.empty), '[NOT] Expected string to be empty, got ``');
+	t.throws(() => m('', m.string.label('foo').not.empty), '[NOT] Expected string `foo` to be empty, got ``');
 });
 
 test('is', t => {
@@ -14,8 +19,11 @@ test('is', t => {
 	};
 
 	t.notThrows(() => m(1, m.number.is(x => x < 10)));
-	t.throws(() => m(1, m.number.is(x => x > 10)), 'Expected `1` to pass custom validation function');
-	t.throws(() => m(5, m.number.is(x => greaterThan(10, x))), 'Expected `5` to be greater than `10`');
+	t.notThrows(() => m(1, m.number.label('foo').is(x => x < 10)));
+	t.throws(() => m(1, m.number.is(x => x > 10)), 'Expected number `1` to pass custom validation function');
+	t.throws(() => m(1, m.number.label('foo').is(x => x > 10)), 'Expected number `foo` `1` to pass custom validation function');
+	t.throws(() => m(5, m.number.is(x => greaterThan(10, x))), '(number) Expected `5` to be greater than `10`');
+	t.throws(() => m(5, m.number.label('foo').is(x => greaterThan(10, x))), '(number `foo`) Expected `5` to be greater than `10`');
 });
 
 test('reusable validator', t => {
@@ -25,4 +33,18 @@ test('reusable validator', t => {
 	t.notThrows(() => checkUsername('foobar'));
 	t.throws(() => checkUsername('fo'), 'Expected string to have a minimum length of `3`, got `fo`');
 	t.throws(() => checkUsername(5 as any), 'Expected argument to be of type `string` but received type `number`');
+});
+
+test('reusable validator with label', t => {
+	const checkUsername = m.create(m.string.label('foo').minLength(3));
+
+	t.notThrows(() => checkUsername('foo'));
+	t.notThrows(() => checkUsername('foobar'));
+	t.throws(() => checkUsername('fo'), 'Expected string `foo` to have a minimum length of `3`, got `fo`');
+	t.throws(() => checkUsername(5 as any), 'Expected `foo` to be of type `string` but received type `number`');
+});
+
+test('overwrite label', t => {
+	t.notThrows(() => m('foo', m.string.label('foo').label('bar')));
+	t.throws(() => m(12 as any, m.string.label('foo').label('bar')), 'Expected `bar` to be of type `string` but received type `number`');
 });

--- a/source/test/typed-array.ts
+++ b/source/test/typed-array.ts
@@ -7,61 +7,61 @@ test('typedArray', t => {
 	t.notThrows(() => m(new Int32Array(2), m.typedArray));
 	t.notThrows(() => m(new Float64Array(2), m.typedArray));
 	t.notThrows(() => m(new Float64Array(2), m.typedArray.label('foo')));
-	t.throws(() => m('foo' as any, m.typedArray), 'Expected argument to be of type `typedArray` but received type `string`');
-	t.throws(() => m('foo' as any, m.typedArray.label('foo')), 'Expected `foo` to be of type `typedArray` but received type `string`');
-	t.throws(() => m(12 as any, m.typedArray), 'Expected argument to be of type `typedArray` but received type `number`');
+	t.throws(() => m('foo' as any, m.typedArray), 'Expected argument to be of type `TypedArray` but received type `string`');
+	t.throws(() => m('foo' as any, m.typedArray.label('foo')), 'Expected `foo` to be of type `TypedArray` but received type `string`');
+	t.throws(() => m(12 as any, m.typedArray), 'Expected argument to be of type `TypedArray` but received type `number`');
 });
 
 test('int8Array', t => {
 	t.notThrows(() => m(new Int8Array(2), m.int8Array));
-	t.throws(() => m('foo' as any, m.int8Array), 'Expected argument to be of type `int8Array` but received type `string`');
-	t.throws(() => m(12 as any, m.int8Array), 'Expected argument to be of type `int8Array` but received type `number`');
+	t.throws(() => m('foo' as any, m.int8Array), 'Expected argument to be of type `Int8Array` but received type `string`');
+	t.throws(() => m(12 as any, m.int8Array), 'Expected argument to be of type `Int8Array` but received type `number`');
 });
 
 test('uint8Array', t => {
 	t.notThrows(() => m(new Uint8Array(2), m.uint8Array));
-	t.throws(() => m('foo' as any, m.uint8Array), 'Expected argument to be of type `uint8Array` but received type `string`');
-	t.throws(() => m(12 as any, m.uint8Array), 'Expected argument to be of type `uint8Array` but received type `number`');
+	t.throws(() => m('foo' as any, m.uint8Array), 'Expected argument to be of type `Uint8Array` but received type `string`');
+	t.throws(() => m(12 as any, m.uint8Array), 'Expected argument to be of type `Uint8Array` but received type `number`');
 });
 
 test('uint8ClampedArray', t => {
 	t.notThrows(() => m(new Uint8ClampedArray(2), m.uint8ClampedArray));
-	t.throws(() => m('foo' as any, m.uint8ClampedArray), 'Expected argument to be of type `uint8ClampedArray` but received type `string`');
-	t.throws(() => m(12 as any, m.uint8ClampedArray), 'Expected argument to be of type `uint8ClampedArray` but received type `number`');
+	t.throws(() => m('foo' as any, m.uint8ClampedArray), 'Expected argument to be of type `Uint8ClampedArray` but received type `string`');
+	t.throws(() => m(12 as any, m.uint8ClampedArray), 'Expected argument to be of type `Uint8ClampedArray` but received type `number`');
 });
 
 test('int16Array', t => {
 	t.notThrows(() => m(new Int16Array(2), m.int16Array));
-	t.throws(() => m('foo' as any, m.int16Array), 'Expected argument to be of type `int16Array` but received type `string`');
-	t.throws(() => m(12 as any, m.int16Array), 'Expected argument to be of type `int16Array` but received type `number`');
+	t.throws(() => m('foo' as any, m.int16Array), 'Expected argument to be of type `Int16Array` but received type `string`');
+	t.throws(() => m(12 as any, m.int16Array), 'Expected argument to be of type `Int16Array` but received type `number`');
 });
 
 test('uint16Array', t => {
 	t.notThrows(() => m(new Uint16Array(2), m.uint16Array));
-	t.throws(() => m('foo' as any, m.uint16Array), 'Expected argument to be of type `uint16Array` but received type `string`');
-	t.throws(() => m(12 as any, m.uint16Array), 'Expected argument to be of type `uint16Array` but received type `number`');
+	t.throws(() => m('foo' as any, m.uint16Array), 'Expected argument to be of type `Uint16Array` but received type `string`');
+	t.throws(() => m(12 as any, m.uint16Array), 'Expected argument to be of type `Uint16Array` but received type `number`');
 });
 
 test('int32Array', t => {
 	t.notThrows(() => m(new Int32Array(2), m.int32Array));
-	t.throws(() => m('foo' as any, m.int32Array), 'Expected argument to be of type `int32Array` but received type `string`');
-	t.throws(() => m(12 as any, m.int32Array), 'Expected argument to be of type `int32Array` but received type `number`');
+	t.throws(() => m('foo' as any, m.int32Array), 'Expected argument to be of type `Int32Array` but received type `string`');
+	t.throws(() => m(12 as any, m.int32Array), 'Expected argument to be of type `Int32Array` but received type `number`');
 });
 
 test('uint32Array', t => {
 	t.notThrows(() => m(new Uint32Array(2), m.uint32Array));
-	t.throws(() => m('foo' as any, m.uint32Array), 'Expected argument to be of type `uint32Array` but received type `string`');
-	t.throws(() => m(12 as any, m.uint32Array), 'Expected argument to be of type `uint32Array` but received type `number`');
+	t.throws(() => m('foo' as any, m.uint32Array), 'Expected argument to be of type `Uint32Array` but received type `string`');
+	t.throws(() => m(12 as any, m.uint32Array), 'Expected argument to be of type `Uint32Array` but received type `number`');
 });
 
 test('float32Array', t => {
 	t.notThrows(() => m(new Float32Array(2), m.float32Array));
-	t.throws(() => m('foo' as any, m.float32Array), 'Expected argument to be of type `float32Array` but received type `string`');
-	t.throws(() => m(12 as any, m.float32Array), 'Expected argument to be of type `float32Array` but received type `number`');
+	t.throws(() => m('foo' as any, m.float32Array), 'Expected argument to be of type `Float32Array` but received type `string`');
+	t.throws(() => m(12 as any, m.float32Array), 'Expected argument to be of type `Float32Array` but received type `number`');
 });
 
 test('float64Array', t => {
 	t.notThrows(() => m(new Float64Array(2), m.float64Array));
-	t.throws(() => m('foo' as any, m.float64Array), 'Expected argument to be of type `float64Array` but received type `string`');
-	t.throws(() => m(12 as any, m.float64Array), 'Expected argument to be of type `float64Array` but received type `number`');
+	t.throws(() => m('foo' as any, m.float64Array), 'Expected argument to be of type `Float64Array` but received type `string`');
+	t.throws(() => m(12 as any, m.float64Array), 'Expected argument to be of type `Float64Array` but received type `number`');
 });

--- a/source/test/typed-array.ts
+++ b/source/test/typed-array.ts
@@ -6,7 +6,9 @@ test('typedArray', t => {
 	t.notThrows(() => m(new Uint8Array(2), m.typedArray));
 	t.notThrows(() => m(new Int32Array(2), m.typedArray));
 	t.notThrows(() => m(new Float64Array(2), m.typedArray));
+	t.notThrows(() => m(new Float64Array(2), m.typedArray.label('foo')));
 	t.throws(() => m('foo' as any, m.typedArray), 'Expected argument to be of type `typedArray` but received type `string`');
+	t.throws(() => m('foo' as any, m.typedArray.label('foo')), 'Expected `foo` to be of type `typedArray` but received type `string`');
 	t.throws(() => m(12 as any, m.typedArray), 'Expected argument to be of type `typedArray` but received type `number`');
 });
 

--- a/source/test/undefined.ts
+++ b/source/test/undefined.ts
@@ -7,7 +7,9 @@ test('undefined', t => {
 
 	t.notThrows(() => m(undefined, m.undefined));
 	t.notThrows(() => m(x, m.undefined));
+	t.notThrows(() => m(x, m.undefined.label('foo')));
 	t.throws(() => m(y, m.undefined), 'Expected argument to be of type `undefined` but received type `number`');
+	t.throws(() => m(y, m.undefined.label('foo')), 'Expected `foo` to be of type `undefined` but received type `number`');
 	t.throws(() => m(null, m.undefined), 'Expected argument to be of type `undefined` but received type `null`');
 	t.throws(() => m('foo', m.undefined), 'Expected argument to be of type `undefined` but received type `string`');
 });

--- a/source/test/weak-map.ts
+++ b/source/test/weak-map.ts
@@ -4,7 +4,9 @@ import m from '..';
 test('weakMap', t => {
 	t.notThrows(() => m(new WeakMap(), m.weakMap));
 	t.notThrows(() => m(new WeakMap([[{foo: 'bar'}, '🦄']]), m.weakMap));
+	t.notThrows(() => m(new WeakMap([[{foo: 'bar'}, '🦄']]), m.weakMap.label('foo')));
 	t.throws(() => m(12 as any, m.weakMap), 'Expected argument to be of type `weakMap` but received type `number`');
+	t.throws(() => m(12 as any, m.weakMap.label('foo')), 'Expected `foo` to be of type `weakMap` but received type `number`');
 });
 
 test('weakMap.hasKeys', t => {
@@ -13,7 +15,11 @@ test('weakMap.hasKeys', t => {
 	const keys = [{x: 1}, {x: 2}, {x: 3}, {x: 4}, {x: 5}, {x: 6}, {x: 7}, {x: 8}, {x: 9}, {x: 10}];
 
 	t.notThrows(() => m(new WeakMap([[unicorn, '🦄']]), m.weakMap.hasKeys(unicorn)));
+	t.notThrows(() => m(new WeakMap([[unicorn, '🦄']]), m.weakMap.label('foo').hasKeys(unicorn)));
+	t.notThrows(() => m(new WeakMap([[unicorn, '🦄']]), m.weakMap.hasKeys(unicorn).label('foo')));
 	t.throws(() => m(new WeakMap([[{rainbow: true}, '🌈']]), m.weakMap.hasKeys({rainbow: true})), 'Expected WeakMap to have keys `[{"rainbow":true}]`');
+	t.throws(() => m(new WeakMap([[{rainbow: true}, '🌈']]), m.weakMap.label('foo').hasKeys({rainbow: true})), 'Expected WeakMap `foo` to have keys `[{"rainbow":true}]`');
+	t.throws(() => m(new WeakMap([[{rainbow: true}, '🌈']]), m.weakMap.hasKeys({rainbow: true}).label('foo')), 'Expected WeakMap `foo` to have keys `[{"rainbow":true}]`');
 	t.throws(() => m(new WeakMap([[unicorn, '🦄'], [rainbow, '🌈']]), m.weakMap.hasKeys(unicorn, {rainbow: true})), 'Expected WeakMap to have keys `[{"rainbow":true}]`');
 	t.throws(() => m(new WeakMap([[keys[0], 1], [keys[2], 3]]), m.weakMap.hasKeys(...keys)), 'Expected WeakMap to have keys `[{"x":2},{"x":4},{"x":5},{"x":6},{"x":7}]`');
 });

--- a/source/test/weak-map.ts
+++ b/source/test/weak-map.ts
@@ -5,8 +5,8 @@ test('weakMap', t => {
 	t.notThrows(() => m(new WeakMap(), m.weakMap));
 	t.notThrows(() => m(new WeakMap([[{foo: 'bar'}, '🦄']]), m.weakMap));
 	t.notThrows(() => m(new WeakMap([[{foo: 'bar'}, '🦄']]), m.weakMap.label('foo')));
-	t.throws(() => m(12 as any, m.weakMap), 'Expected argument to be of type `weakMap` but received type `number`');
-	t.throws(() => m(12 as any, m.weakMap.label('foo')), 'Expected `foo` to be of type `weakMap` but received type `number`');
+	t.throws(() => m(12 as any, m.weakMap), 'Expected argument to be of type `WeakMap` but received type `number`');
+	t.throws(() => m(12 as any, m.weakMap.label('foo')), 'Expected `foo` to be of type `WeakMap` but received type `number`');
 });
 
 test('weakMap.hasKeys', t => {

--- a/source/test/weak-set.ts
+++ b/source/test/weak-set.ts
@@ -10,8 +10,8 @@ test('weakSet', t => {
 	t.notThrows(() => m(new WeakSet([{unicorn: '🦄'}]), m.weakSet));
 	t.notThrows(() => m(new WeakSet([unicorn]), m.weakSet));
 	t.notThrows(() => m(new WeakSet([unicorn]), m.weakSet.label('foo')));
-	t.throws(() => m(12 as any, m.weakSet), 'Expected argument to be of type `weakSet` but received type `number`');
-	t.throws(() => m(12 as any, m.weakSet.label('foo')), 'Expected `foo` to be of type `weakSet` but received type `number`');
+	t.throws(() => m(12 as any, m.weakSet), 'Expected argument to be of type `WeakSet` but received type `number`');
+	t.throws(() => m(12 as any, m.weakSet.label('foo')), 'Expected `foo` to be of type `WeakSet` but received type `number`');
 });
 
 test('weakSet.has', t => {

--- a/source/test/weak-set.ts
+++ b/source/test/weak-set.ts
@@ -9,7 +9,9 @@ test('weakSet', t => {
 	t.notThrows(() => m(new WeakSet(), m.weakSet));
 	t.notThrows(() => m(new WeakSet([{unicorn: '🦄'}]), m.weakSet));
 	t.notThrows(() => m(new WeakSet([unicorn]), m.weakSet));
+	t.notThrows(() => m(new WeakSet([unicorn]), m.weakSet.label('foo')));
 	t.throws(() => m(12 as any, m.weakSet), 'Expected argument to be of type `weakSet` but received type `number`');
+	t.throws(() => m(12 as any, m.weakSet.label('foo')), 'Expected `foo` to be of type `weakSet` but received type `number`');
 });
 
 test('weakSet.has', t => {
@@ -17,7 +19,11 @@ test('weakSet.has', t => {
 
 	t.notThrows(() => m(new WeakSet([unicorn]), m.weakSet.has(unicorn)));
 	t.notThrows(() => m(new WeakSet([unicorn, rainbow]), m.weakSet.has(unicorn, rainbow)));
+	t.notThrows(() => m(new WeakSet([unicorn, rainbow]), m.weakSet.label('foo').has(unicorn, rainbow)));
+	t.notThrows(() => m(new WeakSet([unicorn, rainbow]), m.weakSet.has(unicorn, rainbow).label('foo')));
 	t.throws(() => m(new WeakSet([unicorn, rainbow]), m.weakSet.has(rocket)), 'Expected WeakSet to have items `[{"rocket":"🚀"}]`');
+	t.throws(() => m(new WeakSet([unicorn, rainbow]), m.weakSet.label('foo').has(rocket)), 'Expected WeakSet `foo` to have items `[{"rocket":"🚀"}]`');
+	t.throws(() => m(new WeakSet([unicorn, rainbow]), m.weakSet.has(rocket).label('foo')), 'Expected WeakSet `foo` to have items `[{"rocket":"🚀"}]`');
 	t.throws(() => m(new WeakSet([unicorn, rocket]), m.weakSet.has(rainbow, rocket)), 'Expected WeakSet to have items `[{"rainbow":"🌈"}]`');
 	t.throws(() => m(new WeakSet([keys[1], keys[3]]), m.weakSet.has(...keys)), 'Expected WeakSet to have items `[{"x":1},{"x":3},{"x":5},{"x":6},{"x":7}]`');
 });


### PR DESCRIPTION
This PR fixes #32.

#### Predicate.label(string)

This assigns a custom label to be used in any error messages. It is useful for making error messages more user-friendly by including the name of the variable which failed validation.

This predicate does not add any additional validation.

```ts
ow('', ow.string.nonEmpty);
//=> ArgumentError: Expected string to not be empty

ow('', ow.string.label('foo').nonEmpty);
//=> ArgumentError: Expected string `foo` to not be empty

ow('', ow.string.nonEmpty.label('foo'));
//=> ArgumentError: Expected string `foo` to not be empty

// NOTE: for base type checks, we do not include the "type" in the label because it would be redundant.

ow(1, ow.string);
//=> ArgumentError: 'Expected argument to be of type `string` but received type `number`'

ow(1, ow.string.label('foo'));
//=> ArgumentError: 'Expected `foo` to be of type `string` but received type `number`'
```

A few notes:
- I had to add some small conditional logic to `Predicate.ts` in order for the base type check to still use the name `argument` if no label exists and use the label otherwise. This is the only part that's not 100% as clean as I'd like but I think the more concise and consistent output is worth it.
- Everywhere else, we use `${type} ${label}` (with label in backquotes) as the label and which actually adds a bit of consistency in several places. For instance, for `Set`, `Map`, `WeakMap`, `WeakSet`, and `array`, we used to have error messages say:

```js
`Expected Set to...`

// which has now changed to

`Expected ${label} to...`
```

This allows us to consistently use `${type}` as the identifier unless a label has been set, in which case we use the more verbose `${type} ${label}`.  Some places like `number` were missing the type in their error messages previously, so this generic label solution controlled by the abstract `Predicate` class should be more consistent to help normalize the way we use labels / types across all `Predicate` subclasses.

- I tried to add only the minimum number of tests that would be necessary to cover all the updated functionality & differences in output, but it still ended up being a lot of new tests.
- In a few cases, we're passing an error untouched from a recursive invocation of `ow`. In these cases, I chose to prepend `(${label}) ` before the error message since the error message itself is already set. See `map.keysOfType` for an example of this behavior.
- Afaik, all tests & linting pass locally with coverage still at 100%.

Thanks!