### PR TITLE
Add isValid method - fixes #74

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -49,7 +49,11 @@ unicorn('yo');
 
 ### ow(value, predicate)
 
-Test if `value` matches the provided `predicate`.
+Test if `value` matches the provided `predicate`.  Throws an `ArgumentError` if the test fails.
+
+### ow.isValid(value, predicate)
+
+Returns `true` if the value matches the predicate, otherwise returns `false`.
 
 ### ow.create(predicate)
 

--- a/source/index.ts
+++ b/source/index.ts
@@ -20,12 +20,19 @@ export type TypedArray = Int8Array | Uint8Array | Uint8ClampedArray | Int16Array
 
 export interface Ow {
 	/**
-	 * Test if the value matches the predicate.
+	 * Test if the value matches the predicate. Throws an `ArgumentError` if the test fails..
 	 *
 	 * @param value Value to test.
 	 * @param predicate Predicate to test against.
 	 */
 	<T>(value: T, predicate: Predicate<T>): void;
+	/**
+	 * Returns `true` if the value matches the predicate, otherwise returns `false`.
+	 *
+	 * @param value Value to test.
+	 * @param predicate Predicate to test against.
+	 */
+	isValid<T>(value: T, predicate: Predicate<T>): value is T;
 	/**
 	 * Create a reusable validator.
 	 *
@@ -183,6 +190,16 @@ export interface Ow {
 const main = <T>(value: T, predicate: Predicate<T> | AnyPredicate<T>) => (predicate as any)[testSymbol](value, main);
 
 Object.defineProperties(main, {
+	isValid: {
+		value: <T>(value: T, predicate: Predicate<T>) => {
+			try {
+				main(value, predicate);
+				return true;
+			} catch {
+				return false;
+			}
+		}
+	},
 	create: {
 		value: <T>(predicate: Predicate<T>) => (value: T) => main(value, predicate)
 	},

--- a/source/test/test.ts
+++ b/source/test/test.ts
@@ -18,6 +18,14 @@ test('is', t => {
 	t.throws(() => m(5, m.number.is(x => greaterThan(10, x))), 'Expected `5` to be greater than `10`');
 });
 
+test('isValid', t => {
+	t.true(m.isValid(1, m.number));
+	t.true(m.isValid(1, m.number.equal(1)));
+	t.true(m.isValid('foo!', m.string.not.alphanumeric));
+	t.false(m.isValid(1 as any, m.string));
+	t.false(m.isValid(1 as any, m.number.greaterThan(2)));
+});
+
 test('reusable validator', t => {
 	const checkUsername = m.create(m.string.minLength(3));
 


### PR DESCRIPTION
This PR implements a `isValid` method which returns a boolean instead of throwing like discussed in #74. I went for `isValid` for now but we can always pick a different name. I personally prefer `isValid` the most.