### PR TITLE
Add `string.oneOf` - fixes #80

### DIFF
--- a/source/lib/predicates/string.ts
+++ b/source/lib/predicates/string.ts
@@ -94,6 +94,27 @@ export class StringPredicate extends Predicate<string> {
 	}
 
 	/**
+	 * Test if the string is an element of the provided list.
+	 *
+	 * @param list List of possible values.
+	 */
+	oneOf(list: string[]) {
+		return this.addValidator({
+			message: (value, label) => {
+				let printedList = JSON.stringify(list);
+
+				if (list.length > 10) {
+					const overflow = list.length - 10;
+					printedList = JSON.stringify(list.slice(0, 10)).replace(/]$/, `,…+${overflow} more]`);
+				}
+
+				return `Expected ${label} to be one of \`${printedList}\`, got \`${value}\``;
+			},
+			validator: value => list.includes(value)
+		});
+	}
+
+	/**
 	 * Test a string to be empty.
 	 */
 	get empty() {

--- a/source/test/string.ts
+++ b/source/test/string.ts
@@ -56,6 +56,14 @@ test('string.includes', t => {
 	t.throws(() => m('foo' as any, m.string.includes('bar')), 'Expected string to include `bar`, got `foo`');
 });
 
+test('string.oneOf', t => {
+	t.notThrows(() => m('foo', m.string.oneOf(['foo', 'bar'])));
+	t.throws(() => m('foo', m.string.oneOf(['unicorn', 'rainbow'])), 'Expected string to be one of `["unicorn","rainbow"]`, got `foo`');
+	t.throws(() => m('foo', m.string.oneOf(['unicorn', 'rainbow']).label('hello')), 'Expected string `hello` to be one of `["unicorn","rainbow"]`, got `foo`');
+	t.throws(() => m('foo', m.string.oneOf(['a', 'b', 'c', 'd', 'e'])), 'Expected string to be one of `["a","b","c","d","e"]`, got `foo`');
+	t.throws(() => m('foo', m.string.oneOf(['1', '2', '3', '4', '5', '6', '7', '8', '9', '10', '11', '12', '13'])), 'Expected string to be one of `["1","2","3","4","5","6","7","8","9","10",…+3 more]`, got `foo`');
+});
+
 test('string.empty', t => {
 	t.notThrows(() => m('', m.string.empty));
 	t.throws(() => m('foo' as any, m.string.empty), 'Expected string to be empty, got `foo`');


### PR DESCRIPTION
Added `string.oneOf` as discussed in #80. I was back and forth of cutting off the list in the error message and showing something like

> Expected string to be one of `["a","b","c","d","e",…+2 more]`, got `foo`

Let me know if that's desired.

Let's also wait for #84 so I can rebase my stuff onto that. Probably easier for me to do it.