### PR TITLE
Add new string predicates

### DIFF
--- a/source/lib/predicates/string.ts
+++ b/source/lib/predicates/string.ts
@@ -187,22 +187,22 @@ export class StringPredicate extends Predicate<string> {
 	}
 
 	/**
-	 * Test a string to be lowercase.
+	 * Test a non-empty string to be lowercase. Matching both alphabetical & numbers.
 	 */
 	get lowercase() {
 		return this.addValidator({
-			message: (value, label) => `Expected ${label} to be in lowercase, got \`${value}\``,
-			validator: value => value === value.toLowerCase()
+			message: (value, label) => `Expected ${label} to be lowercase, got \`${value}\``,
+			validator: value => value === (value !== '' && value.toLowerCase())
 		});
 	}
 
 	/**
-	 * Test a string to be uppercase.
+	 * Test a non-empty string to be uppercase. Matching both alphabetical & numbers.
 	 */
 	get uppercase() {
 		return this.addValidator({
-			message: (value, label) => `Expected ${label} to be in uppercase, got \`${value}\``,
-			validator: value => value === value.toUpperCase()
+			message: (value, label) => `Expected ${label} to be uppercase, got \`${value}\``,
+			validator: value => value === (value !== '' && value.toUpperCase())
 		});
 	}
 }

--- a/source/lib/predicates/string.ts
+++ b/source/lib/predicates/string.ts
@@ -157,6 +157,16 @@ export class StringPredicate extends Predicate<string> {
 	}
 
 	/**
+	 * Test a string to be alphabetical.
+	 */
+	get alphabetical() {
+		return this.addValidator({
+			message: (value, label) => `Expected ${label} to be alphabetical, got \`${value}\``,
+			validator: value => /^[a-z]+$/ig.test(value)
+		});
+	}
+
+	/**
 	 * Test a string to be numeric.
 	 */
 	get numeric() {
@@ -173,6 +183,26 @@ export class StringPredicate extends Predicate<string> {
 		return this.addValidator({
 			message: (value, label) => `Expected ${label} to be a date, got \`${value}\``,
 			validator: value => valiDate(value)
+		});
+	}
+
+	/**
+	 * Test a string to be lowercase.
+	 */
+	get lowercase() {
+		return this.addValidator({
+			message: (value, label) => `Expected ${label} to be in lowercase, got \`${value}\``,
+			validator: value => value === value.toLowerCase()
+		});
+	}
+
+	/**
+	 * Test a string to be uppercase.
+	 */
+	get uppercase() {
+		return this.addValidator({
+			message: (value, label) => `Expected ${label} to be in uppercase, got \`${value}\``,
+			validator: value => value === value.toUpperCase()
 		});
 	}
 }

--- a/source/lib/predicates/string.ts
+++ b/source/lib/predicates/string.ts
@@ -192,7 +192,7 @@ export class StringPredicate extends Predicate<string> {
 	get lowercase() {
 		return this.addValidator({
 			message: (value, label) => `Expected ${label} to be lowercase, got \`${value}\``,
-			validator: value => value === (value !== '' && value.toLowerCase())
+			validator: value => value.trim() !== '' && value === value.toLowerCase()
 		});
 	}
 
@@ -202,7 +202,7 @@ export class StringPredicate extends Predicate<string> {
 	get uppercase() {
 		return this.addValidator({
 			message: (value, label) => `Expected ${label} to be uppercase, got \`${value}\``,
-			validator: value => value === (value !== '' && value.toUpperCase())
+			validator: value => value.trim() !== '' && value === value.toUpperCase()
 		});
 	}
 }

--- a/source/test/string.ts
+++ b/source/test/string.ts
@@ -82,8 +82,8 @@ test('string.equals', t => {
 test('string.alphabetical', t => {
 	t.notThrows(() => m('foo', m.string.alphabetical));
 	t.notThrows(() => m('FOO', m.string.alphabetical));
-	t.throws(() => m('foo123' as any, m.string.alphabetical), 'Expected string to be alphabetical, got `foo123`');
-	t.throws(() => m('' as any, m.string.alphabetical), 'Expected string to be alphabetical, got ``');
+	t.throws(() => m('foo123', m.string.alphabetical), 'Expected string to be alphabetical, got `foo123`');
+	t.throws(() => m('', m.string.alphabetical), 'Expected string to be alphabetical, got ``');
 });
 
 test('string.alphanumeric', t => {
@@ -108,14 +108,14 @@ test('string.lowercase', t => {
 	t.notThrows(() => m('foo', m.string.lowercase));
 	t.notThrows(() => m('foo123', m.string.lowercase));
 	t.notThrows(() => m('123', m.string.lowercase));
-	t.throws(() => m('FOO' as any, m.string.lowercase), 'Expected string to be lowercase, got `FOO`');
-	t.throws(() => m('' as any, m.string.lowercase), 'Expected string to be lowercase, got ``');
+	t.throws(() => m('FOO', m.string.lowercase), 'Expected string to be lowercase, got `FOO`');
+	t.throws(() => m('', m.string.lowercase), 'Expected string to be lowercase, got ``');
 });
 
 test('string.uppercase', t => {
 	t.notThrows(() => m('FOO', m.string.uppercase));
 	t.notThrows(() => m('FOO123', m.string.uppercase));
 	t.notThrows(() => m('123', m.string.uppercase));
-	t.throws(() => m('foo' as any, m.string.uppercase), 'Expected string to be uppercase, got `foo`');
-	t.throws(() => m('' as any, m.string.uppercase), 'Expected string to be uppercase, got ``');
+	t.throws(() => m('foo', m.string.uppercase), 'Expected string to be uppercase, got `foo`');
+	t.throws(() => m('', m.string.uppercase), 'Expected string to be uppercase, got ``');
 });

--- a/source/test/string.ts
+++ b/source/test/string.ts
@@ -83,6 +83,7 @@ test('string.alphabetical', t => {
 	t.notThrows(() => m('foo', m.string.alphabetical));
 	t.notThrows(() => m('FOO', m.string.alphabetical));
 	t.throws(() => m('foo123' as any, m.string.alphabetical), 'Expected string to be alphabetical, got `foo123`');
+	t.throws(() => m('' as any, m.string.alphabetical), 'Expected string to be alphabetical, got ``');
 });
 
 test('string.alphanumeric', t => {
@@ -106,11 +107,15 @@ test('string.date', t => {
 test('string.lowercase', t => {
 	t.notThrows(() => m('foo', m.string.lowercase));
 	t.notThrows(() => m('foo123', m.string.lowercase));
-	t.throws(() => m('FOO' as any, m.string.lowercase), 'Expected string to be in lowercase, got `FOO`');
+	t.notThrows(() => m('123', m.string.lowercase));
+	t.throws(() => m('FOO' as any, m.string.lowercase), 'Expected string to be lowercase, got `FOO`');
+	t.throws(() => m('' as any, m.string.lowercase), 'Expected string to be lowercase, got ``');
 });
 
 test('string.uppercase', t => {
 	t.notThrows(() => m('FOO', m.string.uppercase));
 	t.notThrows(() => m('FOO123', m.string.uppercase));
-	t.throws(() => m('foo' as any, m.string.uppercase), 'Expected string to be in uppercase, got `foo`');
+	t.notThrows(() => m('123', m.string.uppercase));
+	t.throws(() => m('foo' as any, m.string.uppercase), 'Expected string to be uppercase, got `foo`');
+	t.throws(() => m('' as any, m.string.uppercase), 'Expected string to be uppercase, got ``');
 });

--- a/source/test/string.ts
+++ b/source/test/string.ts
@@ -79,6 +79,12 @@ test('string.equals', t => {
 	t.throws(() => m('bar' as any, m.string.equals('foo')), 'Expected string to be equal to `foo`, got `bar`');
 });
 
+test('string.alphabetical', t => {
+	t.notThrows(() => m('foo', m.string.alphabetical));
+	t.notThrows(() => m('FOO', m.string.alphabetical));
+	t.throws(() => m('foo123' as any, m.string.alphabetical), 'Expected string to be alphabetical, got `foo123`');
+});
+
 test('string.alphanumeric', t => {
 	t.notThrows(() => m('Foo123', m.string.alphanumeric));
 	t.throws(() => m('Foo123!' as any, m.string.alphanumeric), 'Expected string to be alphanumeric, got `Foo123!`');
@@ -95,4 +101,16 @@ test('string.date', t => {
 	t.notThrows(() => m('2017-03-02T10:00:00Z', m.string.label('bar').date));
 	t.throws(() => m('foo' as any, m.string.date), 'Expected string to be a date, got `foo`');
 	t.throws(() => m('foo' as any, m.string.label('bar').date), 'Expected string `bar` to be a date, got `foo`');
+});
+
+test('string.lowercase', t => {
+	t.notThrows(() => m('foo', m.string.lowercase));
+	t.notThrows(() => m('foo123', m.string.lowercase));
+	t.throws(() => m('FOO' as any, m.string.lowercase), 'Expected string to be in lowercase, got `FOO`');
+});
+
+test('string.uppercase', t => {
+	t.notThrows(() => m('FOO', m.string.uppercase));
+	t.notThrows(() => m('FOO123', m.string.uppercase));
+	t.throws(() => m('foo' as any, m.string.uppercase), 'Expected string to be in uppercase, got `foo`');
 });

--- a/source/test/test.ts
+++ b/source/test/test.ts
@@ -4,11 +4,14 @@ import m from '..';
 test('not', t => {
 	t.notThrows(() => m(1, m.number.not.infinite));
 	t.notThrows(() => m(1, m.number.not.infinite.greaterThan(5)));
-	t.notThrows(() => m('foo!', m.string.not.alphanumeric));
+	t.notThrows(() => m('foo!', m.string.not.alphabetical));
 	t.notThrows(() => m('foo!', m.string.not.alphanumeric));
 	t.notThrows(() => m('foo!', m.string.label('foo').not.alphanumeric));
 	t.notThrows(() => m('foo!', m.string.not.label('foo').alphanumeric));
 	t.notThrows(() => m('foo!', m.string.not.alphanumeric.label('foo')));
+	t.notThrows(() => m('foo', m.string.not.uppercase));
+	t.notThrows(() => m('FOO!', m.string.not.lowercase));
+	t.throws(() => m('FOO!', m.string.not.uppercase));
 	t.throws(() => m('', m.string.not.empty), '[NOT] Expected string to be empty, got ``');
 	t.throws(() => m('', m.string.label('foo').not.empty), '[NOT] Expected string `foo` to be empty, got ``');
 });

--- a/source/test/test.ts
+++ b/source/test/test.ts
@@ -9,9 +9,8 @@ test('not', t => {
 	t.notThrows(() => m('foo!', m.string.label('foo').not.alphanumeric));
 	t.notThrows(() => m('foo!', m.string.not.label('foo').alphanumeric));
 	t.notThrows(() => m('foo!', m.string.not.alphanumeric.label('foo')));
-	t.notThrows(() => m('foo', m.string.not.uppercase));
 	t.notThrows(() => m('FOO!', m.string.not.lowercase));
-	t.throws(() => m('FOO!', m.string.not.uppercase));
+	t.notThrows(() => m('foo!', m.string.not.uppercase));
 	t.throws(() => m('', m.string.not.empty), '[NOT] Expected string to be empty, got ``');
 	t.throws(() => m('', m.string.label('foo').not.empty), '[NOT] Expected string `foo` to be empty, got ``');
 });


### PR DESCRIPTION
Adds new predicates for `String.lowecase` and `String.uppercase` as requested in #97 
also adds new predicate for `String.alphabetical` as requested in #96 

saw that `t.notThrows(() => m('foo!', m.string.not.alphanumeric));` was  double  and rewrote one of them to alphabetical instead

Fixes #96 
Fixes #97