### PR TITLE
Add support for signed numeric values in string predicate - fixes #111

### DIFF
--- a/source/lib/predicates/string.ts
+++ b/source/lib/predicates/string.ts
@@ -172,7 +172,7 @@ export class StringPredicate extends Predicate<string> {
 	get numeric() {
 		return this.addValidator({
 			message: (value, label) => `Expected ${label} to be numeric, got \`${value}\``,
-			validator: value => /^\d+$/i.test(value)
+			validator: value => /^(\+|-)?\d+$/i.test(value)
 		});
 	}
 

--- a/source/test/string.ts
+++ b/source/test/string.ts
@@ -93,7 +93,14 @@ test('string.alphanumeric', t => {
 
 test('string.numeric', t => {
 	t.notThrows(() => m('123', m.string.numeric));
-	t.throws(() => m('Foo123' as any, m.string.numeric), 'Expected string to be numeric, got `Foo123`');
+	t.notThrows(() => m('-123', m.string.numeric));
+	t.notThrows(() => m('+123', m.string.numeric));
+	t.throws(() => m('Foo123', m.string.numeric), 'Expected string to be numeric, got `Foo123`');
+	t.throws(() => m('++123', m.string.numeric), 'Expected string to be numeric, got `++123`');
+	t.throws(() => m('1+1', m.string.numeric), 'Expected string to be numeric, got `1+1`');
+	t.throws(() => m('11-', m.string.numeric), 'Expected string to be numeric, got `11-`');
+	t.throws(() => m('--123', m.string.numeric), 'Expected string to be numeric, got `--123`');
+	t.throws(() => m('+-123', m.string.numeric), 'Expected string to be numeric, got `+-123`');
 });
 
 test('string.date', t => {


### PR DESCRIPTION
This PR adds support for `+` and `-` in the `ow.string.numeric` predicate.