### PR TITLE
Import the `fs` module only in Node.js environments

### DIFF
--- a/source/lib/utils/infer-label.ts
+++ b/source/lib/utils/infer-label.ts
@@ -1,4 +1,4 @@
-import fs from './node/fs';
+import lazyFS from './node/fs';
 import {CallSite} from 'callsites';
 import * as isNode from 'is-node';
 import isValidIdentifier from './is-valid-identifier';
@@ -16,6 +16,9 @@ export const inferLabel = (callsites: CallSite[]) => {
 		// Exit if we are not running in a Node.js environment
 		return;
 	}
+
+	// Load the lazy `fs` module
+	const fs = lazyFS();
 
 	// Grab the stackframe with the `ow` function call
 	const functionCallStackFrame = callsites[1];

--- a/source/lib/utils/node/fs.ts
+++ b/source/lib/utils/node/fs.ts
@@ -1,4 +1,4 @@
 import nodeRequire from './require';
 
-// Re-export the Node.js `fs` module to make sure it doesn't get bundled with front-end apps
-export default nodeRequire('fs');
+// Re-export the Node.js `fs` module lazily to make sure it doesn't get bundled with front-end apps
+export default () => nodeRequire('fs');


### PR DESCRIPTION
I think, and I hope, that this PR fixes the issues with bundlers.