### PR TITLE
Add support for checking C style integer data types

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,7 +83,5 @@
 			"dist/test"
 		]
 	},
-	"dependencies": {
-		"byte-range": "^1.0.0"
-	}
+	"dependencies": {}
 }

--- a/package.json
+++ b/package.json
@@ -82,6 +82,5 @@
 		"exclude": [
 			"dist/test"
 		]
-	},
-	"dependencies": {}
+	}
 }

--- a/package.json
+++ b/package.json
@@ -82,5 +82,8 @@
 		"exclude": [
 			"dist/test"
 		]
+	},
+	"dependencies": {
+		"byte-range": "^1.0.0"
 	}
 }

--- a/source/lib/predicates/number.ts
+++ b/source/lib/predicates/number.ts
@@ -1,5 +1,4 @@
 import is from '@sindresorhus/is';
-import byteRange from 'byte-range';
 import {Predicate, Context} from './predicate';
 
 export class NumberPredicate extends Predicate<number> {
@@ -147,9 +146,12 @@ export class NumberPredicate extends Predicate<number> {
 	 * Test a number to be in a valid range for a uint8.
 	 */
 	get uint8() {
+		const start = 0;
+		const end = 255;
+		
 		return this.addValidator({
-			message: (value, label) => `Expected ${label} to be an integer in range [${byteRange.uint8[0]}..${byteRange.uint8[1]}], got ${value}`,
-			validator: value => is.integer(value) && is.inRange(value, [byteRange.uint8[0], byteRange.uint8[1]])
+			message: (value, label) => `Expected ${label} to be an integer in range [${start}..${end}], got ${value}`,
+			validator: value => is.integer(value) && is.inRange(value, [start, end])
 		});
 	}
 }

--- a/source/lib/predicates/number.ts
+++ b/source/lib/predicates/number.ts
@@ -180,4 +180,43 @@ export class NumberPredicate extends Predicate<number> {
 			validator: value => is.integer(value) && is.inRange(value, [start, end])
 		});
 	}
+
+	/**
+	 * Test a number to be in a valid range for a int8.
+	 */
+	get int8() {
+		const start = -128;
+		const end = 127;
+
+		return this.addValidator({
+			message: (value, label) => `Expected ${label} to be an integer in range [${start}..${end}], got ${value}`,
+			validator: value => is.integer(value) && is.inRange(value, [start, end])
+		});
+	}
+
+	/**
+	 * Test a number to be in a valid range for a int16.
+	 */
+	get int16() {
+		const start = -32768;
+		const end = 32767;
+
+		return this.addValidator({
+			message: (value, label) => `Expected ${label} to be an integer in range [${start}..${end}], got ${value}`,
+			validator: value => is.integer(value) && is.inRange(value, [start, end])
+		});
+	}
+
+	/**
+	 * Test a number to be in a valid range for a int32.
+	 */
+	get int32() {
+		const start = -2147483648;
+		const end = 2147483647;
+
+		return this.addValidator({
+			message: (value, label) => `Expected ${label} to be an integer in range [${start}..${end}], got ${value}`,
+			validator: value => is.integer(value) && is.inRange(value, [start, end])
+		});
+	}
 }

--- a/source/lib/predicates/number.ts
+++ b/source/lib/predicates/number.ts
@@ -143,42 +143,42 @@ export class NumberPredicate extends Predicate<number> {
 	}
 
 	/**
-	 * Test a number to be in a valid range for a uint8.
+	 * Test a number to be in a valid range for a 8-bit unsigned integer.
 	 */
 	get uint8() {
 		return this.integer.inRange(0, 255);
 	}
 
 	/**
-	 * Test a number to be in a valid range for a uint16.
+	 * Test a number to be in a valid range for a 16-bit unsigned integer.
 	 */
 	get uint16() {
 		return this.integer.inRange(0, 65535);
 	}
 
 	/**
-	 * Test a number to be in a valid range for a uint32.
+	 * Test a number to be in a valid range for a 32-bit unsigned integer.
 	 */
 	get uint32() {
 		return this.integer.inRange(0, 4294967295);
 	}
 
 	/**
-	 * Test a number to be in a valid range for a int8.
+	 * Test a number to be in a valid range for a 8.-bit signed integer.
 	 */
 	get int8() {
 		return this.integer.inRange(-128, 127);
 	}
 
 	/**
-	 * Test a number to be in a valid range for a int16.
+	 * Test a number to be in a valid range for a 16-bit signed integer.
 	 */
 	get int16() {
 		return this.integer.inRange(-32768, 32767);
 	}
 
 	/**
-	 * Test a number to be in a valid range for a int32.
+	 * Test a number to be in a valid range for a 32-bit signed integer.
 	 */
 	get int32() {
 		return this.integer.inRange(-2147483648, 2147483647);

--- a/source/lib/predicates/number.ts
+++ b/source/lib/predicates/number.ts
@@ -146,77 +146,41 @@ export class NumberPredicate extends Predicate<number> {
 	 * Test a number to be in a valid range for a uint8.
 	 */
 	get uint8() {
-		const start = 0;
-		const end = 255;
-
-		return this.addValidator({
-			message: (value, label) => `Expected ${label} to be an integer in the range ${start}...${end}, got ${value}`,
-			validator: value => is.integer(value) && is.inRange(value, [start, end])
-		});
+		return this.integer.inRange(0, 255);
 	}
 
 	/**
 	 * Test a number to be in a valid range for a uint16.
 	 */
 	get uint16() {
-		const start = 0;
-		const end = 65535;
-
-		return this.addValidator({
-			message: (value, label) => `Expected ${label} to be an integer in the range ${start}...${end}, got ${value}`,
-			validator: value => is.integer(value) && is.inRange(value, [start, end])
-		});
+		return this.integer.inRange(0, 65535);
 	}
 
 	/**
 	 * Test a number to be in a valid range for a uint32.
 	 */
 	get uint32() {
-		const start = 0;
-		const end = 4294967295;
-
-		return this.addValidator({
-			message: (value, label) => `Expected ${label} to be an integer in the range ${start}...${end}, got ${value}`,
-			validator: value => is.integer(value) && is.inRange(value, [start, end])
-		});
+		return this.integer.inRange(0, 4294967295);
 	}
 
 	/**
 	 * Test a number to be in a valid range for a int8.
 	 */
 	get int8() {
-		const start = -128;
-		const end = 127;
-
-		return this.addValidator({
-			message: (value, label) => `Expected ${label} to be an integer in the range ${start}...${end}, got ${value}`,
-			validator: value => is.integer(value) && is.inRange(value, [start, end])
-		});
+		return this.integer.inRange(-128, 127);
 	}
 
 	/**
 	 * Test a number to be in a valid range for a int16.
 	 */
 	get int16() {
-		const start = -32768;
-		const end = 32767;
-
-		return this.addValidator({
-			message: (value, label) => `Expected ${label} to be an integer in the range ${start}...${end}, got ${value}`,
-			validator: value => is.integer(value) && is.inRange(value, [start, end])
-		});
+		return this.integer.inRange(-32768, 32767);
 	}
 
 	/**
 	 * Test a number to be in a valid range for a int32.
 	 */
 	get int32() {
-		const start = -2147483648;
-		const end = 2147483647;
-
-		return this.addValidator({
-			message: (value, label) => `Expected ${label} to be an integer in the range ${start}...${end}, got ${value}`,
-			validator: value => is.integer(value) && is.inRange(value, [start, end])
-		});
+		return this.integer.inRange(-2147483648, 2147483647);
 	}
 }

--- a/source/lib/predicates/number.ts
+++ b/source/lib/predicates/number.ts
@@ -164,7 +164,7 @@ export class NumberPredicate extends Predicate<number> {
 	}
 
 	/**
-	 * Test a number to be in a valid range for a 8.-bit signed integer.
+	 * Test a number to be in a valid range for a 8-bit signed integer.
 	 */
 	get int8() {
 		return this.integer.inRange(-128, 127);

--- a/source/lib/predicates/number.ts
+++ b/source/lib/predicates/number.ts
@@ -150,7 +150,7 @@ export class NumberPredicate extends Predicate<number> {
 		const end = 255;
 
 		return this.addValidator({
-			message: (value, label) => `Expected ${label} to be an integer in range [${start}..${end}], got ${value}`,
+			message: (value, label) => `Expected ${label} to be an integer in the range ${start}...${end}, got ${value}`,
 			validator: value => is.integer(value) && is.inRange(value, [start, end])
 		});
 	}
@@ -163,7 +163,7 @@ export class NumberPredicate extends Predicate<number> {
 		const end = 65535;
 
 		return this.addValidator({
-			message: (value, label) => `Expected ${label} to be an integer in range [${start}..${end}], got ${value}`,
+			message: (value, label) => `Expected ${label} to be an integer in the range ${start}...${end}, got ${value}`,
 			validator: value => is.integer(value) && is.inRange(value, [start, end])
 		});
 	}
@@ -176,7 +176,7 @@ export class NumberPredicate extends Predicate<number> {
 		const end = 4294967295;
 
 		return this.addValidator({
-			message: (value, label) => `Expected ${label} to be an integer in range [${start}..${end}], got ${value}`,
+			message: (value, label) => `Expected ${label} to be an integer in the range ${start}...${end}, got ${value}`,
 			validator: value => is.integer(value) && is.inRange(value, [start, end])
 		});
 	}
@@ -189,7 +189,7 @@ export class NumberPredicate extends Predicate<number> {
 		const end = 127;
 
 		return this.addValidator({
-			message: (value, label) => `Expected ${label} to be an integer in range [${start}..${end}], got ${value}`,
+			message: (value, label) => `Expected ${label} to be an integer in the range ${start}...${end}, got ${value}`,
 			validator: value => is.integer(value) && is.inRange(value, [start, end])
 		});
 	}
@@ -202,7 +202,7 @@ export class NumberPredicate extends Predicate<number> {
 		const end = 32767;
 
 		return this.addValidator({
-			message: (value, label) => `Expected ${label} to be an integer in range [${start}..${end}], got ${value}`,
+			message: (value, label) => `Expected ${label} to be an integer in the range ${start}...${end}, got ${value}`,
 			validator: value => is.integer(value) && is.inRange(value, [start, end])
 		});
 	}
@@ -215,7 +215,7 @@ export class NumberPredicate extends Predicate<number> {
 		const end = 2147483647;
 
 		return this.addValidator({
-			message: (value, label) => `Expected ${label} to be an integer in range [${start}..${end}], got ${value}`,
+			message: (value, label) => `Expected ${label} to be an integer in the range ${start}...${end}, got ${value}`,
 			validator: value => is.integer(value) && is.inRange(value, [start, end])
 		});
 	}

--- a/source/lib/predicates/number.ts
+++ b/source/lib/predicates/number.ts
@@ -1,4 +1,5 @@
 import is from '@sindresorhus/is';
+import byteRange from 'byte-range';
 import {Predicate, Context} from './predicate';
 
 export class NumberPredicate extends Predicate<number> {
@@ -139,6 +140,16 @@ export class NumberPredicate extends Predicate<number> {
 		return this.addValidator({
 			message: (value, label) => `Expected ${label} to be an integer or infinite, got ${value}`,
 			validator: value => is.integer(value) || is.infinite(value)
+		});
+	}
+
+	/**
+	 * Test a number to be in a valid range for a uint8.
+	 */
+	get uint8() {
+		return this.addValidator({
+			message: (value, label) => `Expected ${label} to be an integer in range [${byteRange.uint8[0]}..${byteRange.uint8[1]}], got ${value}`,
+			validator: value => is.integer(value) && is.inRange(value, [byteRange.uint8[0], byteRange.uint8[1]])
 		});
 	}
 }

--- a/source/lib/predicates/number.ts
+++ b/source/lib/predicates/number.ts
@@ -148,7 +148,20 @@ export class NumberPredicate extends Predicate<number> {
 	get uint8() {
 		const start = 0;
 		const end = 255;
-		
+
+		return this.addValidator({
+			message: (value, label) => `Expected ${label} to be an integer in range [${start}..${end}], got ${value}`,
+			validator: value => is.integer(value) && is.inRange(value, [start, end])
+		});
+	}
+
+	/**
+	 * Test a number to be in a valid range for a uint16.
+	 */
+	get uint16() {
+		const start = 0;
+		const end = 65535;
+
 		return this.addValidator({
 			message: (value, label) => `Expected ${label} to be an integer in range [${start}..${end}], got ${value}`,
 			validator: value => is.integer(value) && is.inRange(value, [start, end])

--- a/source/lib/predicates/number.ts
+++ b/source/lib/predicates/number.ts
@@ -167,4 +167,17 @@ export class NumberPredicate extends Predicate<number> {
 			validator: value => is.integer(value) && is.inRange(value, [start, end])
 		});
 	}
+
+	/**
+	 * Test a number to be in a valid range for a uint32.
+	 */
+	get uint32() {
+		const start = 0;
+		const end = 4294967295;
+
+		return this.addValidator({
+			message: (value, label) => `Expected ${label} to be an integer in range [${start}..${end}], got ${value}`,
+			validator: value => is.integer(value) && is.inRange(value, [start, end])
+		});
+	}
 }

--- a/source/test/number.ts
+++ b/source/test/number.ts
@@ -106,3 +106,27 @@ test('number.uint32', t => {
 	t.throws(() => m(1.5, m.number.uint32), 'Expected number to be an integer in range [0..4294967295], got 1.5');
 	t.throws(() => m(4294967296, m.number.uint32), 'Expected number to be an integer in range [0..4294967295], got 4294967296');
 });
+
+test('number.int8', t => {
+	t.notThrows(() => m(-128, m.number.int8));
+	t.notThrows(() => m(127, m.number.int8));
+	t.throws(() => m(-129, m.number.int8), 'Expected number to be an integer in range [-128..127], got -129');
+	t.throws(() => m(1.5, m.number.int8), 'Expected number to be an integer in range [-128..127], got 1.5');
+	t.throws(() => m(128, m.number.int8), 'Expected number to be an integer in range [-128..127], got 128');
+});
+
+test('number.int16', t => {
+	t.notThrows(() => m(-32768, m.number.int16));
+	t.notThrows(() => m(32767, m.number.int16));
+	t.throws(() => m(-32769, m.number.int16), 'Expected number to be an integer in range [-32768..32767], got -32769');
+	t.throws(() => m(1.5, m.number.int16), 'Expected number to be an integer in range [-32768..32767], got 1.5');
+	t.throws(() => m(32768, m.number.int16), 'Expected number to be an integer in range [-32768..32767], got 32768');
+});
+
+test('number.int32', t => {
+	t.notThrows(() => m(-2147483648, m.number.int32));
+	t.notThrows(() => m(2147483647, m.number.int32));
+	t.throws(() => m(-2147483649, m.number.int32), 'Expected number to be an integer in range [-2147483648..2147483647], got -2147483649');
+	t.throws(() => m(1.5, m.number.int32), 'Expected number to be an integer in range [-2147483648..2147483647], got 1.5');
+	t.throws(() => m(2147483648, m.number.int32), 'Expected number to be an integer in range [-2147483648..2147483647], got 2147483648');
+});

--- a/source/test/number.ts
+++ b/source/test/number.ts
@@ -98,3 +98,11 @@ test('number.uint16', t => {
 	t.throws(() => m(1.5, m.number.uint16), 'Expected number to be an integer in range [0..65535], got 1.5');
 	t.throws(() => m(65536, m.number.uint16), 'Expected number to be an integer in range [0..65535], got 65536');
 });
+
+test('number.uint32', t => {
+	t.notThrows(() => m(0, m.number.uint32));
+	t.notThrows(() => m(4294967295, m.number.uint32));
+	t.throws(() => m(-1, m.number.uint32), 'Expected number to be an integer in range [0..4294967295], got -1');
+	t.throws(() => m(1.5, m.number.uint32), 'Expected number to be an integer in range [0..4294967295], got 1.5');
+	t.throws(() => m(4294967296, m.number.uint32), 'Expected number to be an integer in range [0..4294967295], got 4294967296');
+});

--- a/source/test/number.ts
+++ b/source/test/number.ts
@@ -86,47 +86,47 @@ test('number.integerOrInfinite', t => {
 test('number.uint8', t => {
 	t.notThrows(() => m(0, m.number.uint8));
 	t.notThrows(() => m(255, m.number.uint8));
-	t.throws(() => m(-1, m.number.uint8), 'Expected number to be an integer in range [0..255], got -1');
-	t.throws(() => m(1.5, m.number.uint8), 'Expected number to be an integer in range [0..255], got 1.5');
-	t.throws(() => m(256, m.number.uint8), 'Expected number to be an integer in range [0..255], got 256');
+	t.throws(() => m(-1, m.number.uint8), 'Expected number to be an integer in the range 0...255, got -1');
+	t.throws(() => m(1.5, m.number.uint8), 'Expected number to be an integer in the range 0...255, got 1.5');
+	t.throws(() => m(256, m.number.uint8), 'Expected number to be an integer in the range 0...255, got 256');
 });
 
 test('number.uint16', t => {
 	t.notThrows(() => m(0, m.number.uint16));
 	t.notThrows(() => m(65535, m.number.uint16));
-	t.throws(() => m(-1, m.number.uint16), 'Expected number to be an integer in range [0..65535], got -1');
-	t.throws(() => m(1.5, m.number.uint16), 'Expected number to be an integer in range [0..65535], got 1.5');
-	t.throws(() => m(65536, m.number.uint16), 'Expected number to be an integer in range [0..65535], got 65536');
+	t.throws(() => m(-1, m.number.uint16), 'Expected number to be an integer in the range 0...65535, got -1');
+	t.throws(() => m(1.5, m.number.uint16), 'Expected number to be an integer in the range 0...65535, got 1.5');
+	t.throws(() => m(65536, m.number.uint16), 'Expected number to be an integer in the range 0...65535, got 65536');
 });
 
 test('number.uint32', t => {
 	t.notThrows(() => m(0, m.number.uint32));
 	t.notThrows(() => m(4294967295, m.number.uint32));
-	t.throws(() => m(-1, m.number.uint32), 'Expected number to be an integer in range [0..4294967295], got -1');
-	t.throws(() => m(1.5, m.number.uint32), 'Expected number to be an integer in range [0..4294967295], got 1.5');
-	t.throws(() => m(4294967296, m.number.uint32), 'Expected number to be an integer in range [0..4294967295], got 4294967296');
+	t.throws(() => m(-1, m.number.uint32), 'Expected number to be an integer in the range 0...4294967295, got -1');
+	t.throws(() => m(1.5, m.number.uint32), 'Expected number to be an integer in the range 0...4294967295, got 1.5');
+	t.throws(() => m(4294967296, m.number.uint32), 'Expected number to be an integer in the range 0...4294967295, got 4294967296');
 });
 
 test('number.int8', t => {
 	t.notThrows(() => m(-128, m.number.int8));
 	t.notThrows(() => m(127, m.number.int8));
-	t.throws(() => m(-129, m.number.int8), 'Expected number to be an integer in range [-128..127], got -129');
-	t.throws(() => m(1.5, m.number.int8), 'Expected number to be an integer in range [-128..127], got 1.5');
-	t.throws(() => m(128, m.number.int8), 'Expected number to be an integer in range [-128..127], got 128');
+	t.throws(() => m(-129, m.number.int8), 'Expected number to be an integer in the range -128...127, got -129');
+	t.throws(() => m(1.5, m.number.int8), 'Expected number to be an integer in the range -128...127, got 1.5');
+	t.throws(() => m(128, m.number.int8), 'Expected number to be an integer in the range -128...127, got 128');
 });
 
 test('number.int16', t => {
 	t.notThrows(() => m(-32768, m.number.int16));
 	t.notThrows(() => m(32767, m.number.int16));
-	t.throws(() => m(-32769, m.number.int16), 'Expected number to be an integer in range [-32768..32767], got -32769');
-	t.throws(() => m(1.5, m.number.int16), 'Expected number to be an integer in range [-32768..32767], got 1.5');
-	t.throws(() => m(32768, m.number.int16), 'Expected number to be an integer in range [-32768..32767], got 32768');
+	t.throws(() => m(-32769, m.number.int16), 'Expected number to be an integer in the range -32768...32767, got -32769');
+	t.throws(() => m(1.5, m.number.int16), 'Expected number to be an integer in the range -32768...32767, got 1.5');
+	t.throws(() => m(32768, m.number.int16), 'Expected number to be an integer in the range -32768...32767, got 32768');
 });
 
 test('number.int32', t => {
 	t.notThrows(() => m(-2147483648, m.number.int32));
 	t.notThrows(() => m(2147483647, m.number.int32));
-	t.throws(() => m(-2147483649, m.number.int32), 'Expected number to be an integer in range [-2147483648..2147483647], got -2147483649');
-	t.throws(() => m(1.5, m.number.int32), 'Expected number to be an integer in range [-2147483648..2147483647], got 1.5');
-	t.throws(() => m(2147483648, m.number.int32), 'Expected number to be an integer in range [-2147483648..2147483647], got 2147483648');
+	t.throws(() => m(-2147483649, m.number.int32), 'Expected number to be an integer in the range -2147483648...2147483647, got -2147483649');
+	t.throws(() => m(1.5, m.number.int32), 'Expected number to be an integer in the range -2147483648...2147483647, got 1.5');
+	t.throws(() => m(2147483648, m.number.int32), 'Expected number to be an integer in the range -2147483648...2147483647, got 2147483648');
 });

--- a/source/test/number.ts
+++ b/source/test/number.ts
@@ -90,3 +90,11 @@ test('number.uint8', t => {
 	t.throws(() => m(1.5, m.number.uint8), 'Expected number to be an integer in range [0..255], got 1.5');
 	t.throws(() => m(256, m.number.uint8), 'Expected number to be an integer in range [0..255], got 256');
 });
+
+test('number.uint16', t => {
+	t.notThrows(() => m(0, m.number.uint16));
+	t.notThrows(() => m(65535, m.number.uint16));
+	t.throws(() => m(-1, m.number.uint16), 'Expected number to be an integer in range [0..65535], got -1');
+	t.throws(() => m(1.5, m.number.uint16), 'Expected number to be an integer in range [0..65535], got 1.5');
+	t.throws(() => m(65536, m.number.uint16), 'Expected number to be an integer in range [0..65535], got 65536');
+});

--- a/source/test/number.ts
+++ b/source/test/number.ts
@@ -86,47 +86,47 @@ test('number.integerOrInfinite', t => {
 test('number.uint8', t => {
 	t.notThrows(() => m(0, m.number.uint8));
 	t.notThrows(() => m(255, m.number.uint8));
-	t.throws(() => m(-1, m.number.uint8), 'Expected number to be an integer in the range 0...255, got -1');
-	t.throws(() => m(1.5, m.number.uint8), 'Expected number to be an integer in the range 0...255, got 1.5');
-	t.throws(() => m(256, m.number.uint8), 'Expected number to be an integer in the range 0...255, got 256');
+	t.throws(() => m(-1, m.number.uint8), 'Expected number to be in range [0..255], got -1');
+	t.throws(() => m(1.5, m.number.uint8), 'Expected number to be an integer, got 1.5');
+	t.throws(() => m(256, m.number.uint8), 'Expected number to be in range [0..255], got 256');
 });
 
 test('number.uint16', t => {
 	t.notThrows(() => m(0, m.number.uint16));
 	t.notThrows(() => m(65535, m.number.uint16));
-	t.throws(() => m(-1, m.number.uint16), 'Expected number to be an integer in the range 0...65535, got -1');
-	t.throws(() => m(1.5, m.number.uint16), 'Expected number to be an integer in the range 0...65535, got 1.5');
-	t.throws(() => m(65536, m.number.uint16), 'Expected number to be an integer in the range 0...65535, got 65536');
+	t.throws(() => m(-1, m.number.uint16), 'Expected number to be in range [0..65535], got -1');
+	t.throws(() => m(1.5, m.number.uint16), 'Expected number to be an integer, got 1.5');
+	t.throws(() => m(65536, m.number.uint16), 'Expected number to be in range [0..65535], got 65536');
 });
 
 test('number.uint32', t => {
 	t.notThrows(() => m(0, m.number.uint32));
 	t.notThrows(() => m(4294967295, m.number.uint32));
-	t.throws(() => m(-1, m.number.uint32), 'Expected number to be an integer in the range 0...4294967295, got -1');
-	t.throws(() => m(1.5, m.number.uint32), 'Expected number to be an integer in the range 0...4294967295, got 1.5');
-	t.throws(() => m(4294967296, m.number.uint32), 'Expected number to be an integer in the range 0...4294967295, got 4294967296');
+	t.throws(() => m(-1, m.number.uint32), 'Expected number to be in range [0..4294967295], got -1');
+	t.throws(() => m(1.5, m.number.uint32), 'Expected number to be an integer, got 1.5');
+	t.throws(() => m(4294967296, m.number.uint32), 'Expected number to be in range [0..4294967295], got 4294967296');
 });
 
 test('number.int8', t => {
 	t.notThrows(() => m(-128, m.number.int8));
 	t.notThrows(() => m(127, m.number.int8));
-	t.throws(() => m(-129, m.number.int8), 'Expected number to be an integer in the range -128...127, got -129');
-	t.throws(() => m(1.5, m.number.int8), 'Expected number to be an integer in the range -128...127, got 1.5');
-	t.throws(() => m(128, m.number.int8), 'Expected number to be an integer in the range -128...127, got 128');
+	t.throws(() => m(-129, m.number.int8), 'Expected number to be in range [-128..127], got -129');
+	t.throws(() => m(1.5, m.number.int8), 'Expected number to be an integer, got 1.5');
+	t.throws(() => m(128, m.number.int8), 'Expected number to be in range [-128..127], got 128');
 });
 
 test('number.int16', t => {
 	t.notThrows(() => m(-32768, m.number.int16));
 	t.notThrows(() => m(32767, m.number.int16));
-	t.throws(() => m(-32769, m.number.int16), 'Expected number to be an integer in the range -32768...32767, got -32769');
-	t.throws(() => m(1.5, m.number.int16), 'Expected number to be an integer in the range -32768...32767, got 1.5');
-	t.throws(() => m(32768, m.number.int16), 'Expected number to be an integer in the range -32768...32767, got 32768');
+	t.throws(() => m(-32769, m.number.int16), 'Expected number to be in range [-32768..32767], got -32769');
+	t.throws(() => m(1.5, m.number.int16), 'Expected number to be an integer, got 1.5');
+	t.throws(() => m(32768, m.number.int16), 'Expected number to be in range [-32768..32767], got 32768');
 });
 
 test('number.int32', t => {
 	t.notThrows(() => m(-2147483648, m.number.int32));
 	t.notThrows(() => m(2147483647, m.number.int32));
-	t.throws(() => m(-2147483649, m.number.int32), 'Expected number to be an integer in the range -2147483648...2147483647, got -2147483649');
-	t.throws(() => m(1.5, m.number.int32), 'Expected number to be an integer in the range -2147483648...2147483647, got 1.5');
-	t.throws(() => m(2147483648, m.number.int32), 'Expected number to be an integer in the range -2147483648...2147483647, got 2147483648');
+	t.throws(() => m(-2147483649, m.number.int32), 'Expected number to be in range [-2147483648..2147483647], got -2147483649');
+	t.throws(() => m(1.5, m.number.int32), 'Expected number to be an integer, got 1.5');
+	t.throws(() => m(2147483648, m.number.int32), 'Expected number to be in range [-2147483648..2147483647], got 2147483648');
 });

--- a/source/test/number.ts
+++ b/source/test/number.ts
@@ -82,3 +82,11 @@ test('number.integerOrInfinite', t => {
 	t.notThrows(() => m(-10, m.number.integerOrInfinite));
 	t.throws(() => m(3.14, m.number.integerOrInfinite), 'Expected number to be an integer or infinite, got 3.14');
 });
+
+test('number.uint8', t => {
+	t.notThrows(() => m(0, m.number.uint8));
+	t.notThrows(() => m(255, m.number.uint8));
+	t.throws(() => m(-1, m.number.uint8), 'Expected number to be an integer in range [0..255], got -1');
+	t.throws(() => m(1.5, m.number.uint8), 'Expected number to be an integer in range [0..255], got 1.5');
+	t.throws(() => m(256, m.number.uint8), 'Expected number to be an integer in range [0..255], got 256');
+});


### PR DESCRIPTION
Resolves #118 

~~**Just opening this for some feedback, not ready to merge yet.**~~

I've never used TypeScript before so have a few questions:

1. I wrote [`byte-range`](https://github.com/lukechilds/byte-range) as a separate lib but I'm getting errors because it's not written in TypeScript:

```
source/lib/predicates/number.ts:2:23 - error TS7016: Could not find a declaration file for module 'byte-range'. '/Users/lukechilds/dev/oss/ow/node_modules/byte-range/src/index.js' implicitly has an 'any' type.
  Try `npm install @types/byte-range` if it exists or add a new declaration (.d.ts) file containing `declare module 'byte-range';`

2 import byteRange from 'byte-range';
```

So looks like my options are add a definitions file or refactor it to use TypeScript. I know this module is advertised as being written in TypeScript so I'm assuming that would be a requirement of `byte-range` to be a dependency?

2. I noticed all dependencies are under `devDependencies`.

Why is this? Do you want me to move `byte-range` to `devDependencies` too?

3. Is there a way to add getters to the `NumberPredicate` class in a loop?

The current code for uint8 (https://github.com/sindresorhus/ow/commit/7134c23b53c4d6be1a78e1ecd1f7781483822f2c) will be practically identical for uint16, uint32, int8, int16 and int32. It would add way less code bloat to just loop over an array of `['uint8', 'uint16', 'uint32', 'int8', 'int16', 'int32']` and add the getters.