### PR TITLE
Hide private functions in the documentation

### DIFF
--- a/source/lib/utils/infer-label.ts
+++ b/source/lib/utils/infer-label.ts
@@ -9,6 +9,7 @@ const labelRegex = /^.*?\((.*?)[,)]/;
 /**
  * Infer the label of the caller.
  *
+ * @hidden
  * @param callsites - List of stack frames.
  */
 export const inferLabel = (callsites: CallSite[]) => {

--- a/source/test/fixtures/create-error.ts
+++ b/source/test/fixtures/create-error.ts
@@ -1,3 +1,6 @@
+/**
+ * @hidden
+ */
 export const createAnyError = (...errors: string[]) => {
 	return [
 		'Any predicate failed with the following errors:',


### PR DESCRIPTION
These two annoations remove the `inferLabel` and `createAnyError` from the docs. Tested it locally and it works.