### PR TITLE
Check for optional first before running validator

### DIFF
--- a/source/lib/predicates/predicate.ts
+++ b/source/lib/predicates/predicate.ts
@@ -70,9 +70,13 @@ export class Predicate<T = any> implements BasePredicate<T> {
 	// tslint:disable completed-docs
 	[testSymbol](value: T, main: Main, label: string | Function) {
 		for (const {validator, message} of this.context.validators) {
+			if (this.options.optional === true && value === undefined) {
+				continue;
+			}
+
 			const result = validator(value);
 
-			if (result === true || (this.options.optional === true && value === undefined)) {
+			if (result === true) {
 				continue;
 			}
 

--- a/source/test/optional.ts
+++ b/source/test/optional.ts
@@ -4,6 +4,7 @@ import ow from '..';
 test('optional', t => {
 	t.notThrows(() => ow(1, ow.optional.number));
 	t.notThrows(() => ow(undefined, ow.optional.number));
+	t.notThrows(() => ow(undefined, ow.optional.string.minLength(3)));
 	t.notThrows(() => ow(undefined, ow.optional.any(ow.string, ow.number)));
 	t.throws(() => ow(null, ow.optional.number), 'Expected argument to be of type `number` but received type `null`');
 	t.throws(() => ow('1' as any, ow.optional.number), 'Expected argument to be of type `number` but received type `string`');


### PR DESCRIPTION
The `optional` predicate currently has a bug. The bug is that the validator is still executed, even when the value is `undefined`. This is wrong off course because in case of this use case

```ts
ow(undefined, ow.optional.string.minLength(3));
```

The predicate will do `undefined.length` which throws a `Cannot read property 'length' of 'undefined'` (or something).

This PR doesn't do that (performance benefit because it doesn't run all the validators) as it first checks if it's `optional` and if the `value` is `undefined`.