### PR TITLE
Add `number.oneOf`

### DIFF
--- a/source/predicates/number.ts
+++ b/source/predicates/number.ts
@@ -83,6 +83,27 @@ export class NumberPredicate extends Predicate<number> {
 	}
 
 	/**
+	 * Test if a number is an element of the provided list.
+	 *
+	 * @param list List of possible values.
+	 */
+	oneOf(list: number[]) {
+		return this.addValidator({
+			message: (value, label) => {
+				let printedList = JSON.stringify(list);
+
+				if (list.length > 10) {
+					const overflow = list.length - 10;
+					printedList = JSON.stringify(list.slice(0, 10)).replace(/]$/, `,…+${overflow} more]`);
+				}
+
+				return `Expected ${label} to be one of \`${printedList}\`, got ${value}`;
+			},
+			validator: value => list.includes(value)
+		});
+	}
+
+	/**
 	 * Test a number to be an integer.
 	 */
 	get integer() {

--- a/test/number.ts
+++ b/test/number.ts
@@ -130,6 +130,28 @@ test('number.equal', t => {
 	}, 'Expected number to be equal to 5, got 10');
 });
 
+test('number.oneOf', t => {
+	t.notThrows(() => {
+		ow(10, ow.number.oneOf([5, 10]));
+	});
+
+	t.throws(() => {
+		ow(10, ow.number.oneOf([5, 6]));
+	}, 'Expected number to be one of `[5,6]`, got 10');
+
+	t.throws(() => {
+		ow(10, 'hello', ow.number.oneOf([5, 6]));
+	}, 'Expected number `hello` to be one of `[5,6]`, got 10');
+
+	t.throws(() => {
+		ow(10, ow.number.oneOf([5, 6, 7, 8, 9]));
+	}, 'Expected number to be one of `[5,6,7,8,9]`, got 10');
+
+	t.throws(() => {
+		ow(10, ow.number.oneOf([5, 6, 7, 8, 9, 11, 12, 13, 14, 15, 16, 17, 18]));
+	}, 'Expected number to be one of `[5,6,7,8,9,11,12,13,14,15,…+3 more]`, got 10');
+});
+
 test('number.integer', t => {
 	t.notThrows(() => {
 		ow(10, ow.number.integer);


### PR DESCRIPTION
I was writing some validation and had to make sure a number was just one of two values. I remembered that there was on option on string to do `oneOf`, which would solve my problem.

This might be a valid use case for others, so I implemented it.

The implementation is almost the same as in the `string` predicate. (see my comments in the file to explain the differences.