### PR TITLE
Only call captureStackTrace when possible

### DIFF
--- a/source/argument-error.ts
+++ b/source/argument-error.ts
@@ -5,7 +5,9 @@ export class ArgumentError extends Error {
 	constructor(message: string, context: Function) {
 		super(message);
 		// TODO: Node does not preserve the error name in output when using the below, why?
-		Error.captureStackTrace(this, context);
+		if ('captureStackTrace' in Error) {
+			Error.captureStackTrace(this, context);
+		}
 		this.name = 'ArgumentError';
 	}
 }

--- a/source/index.ts
+++ b/source/index.ts
@@ -50,7 +50,7 @@ export interface Ow extends Modifiers, Predicates {
 	create<T>(label: string, predicate: BasePredicate<T>): (value: T) => void;
 }
 
-const ow = <T>(value: T, labelOrPredicate: any, predicate?: BasePredicate<T>) => {
+const ow: any = <T>(value: T, labelOrPredicate: any, predicate?: BasePredicate<T>) => {
 	if (!isPredicate(labelOrPredicate) && typeof labelOrPredicate !== 'string') {
 		throw new TypeError(`Expected second argument to be a predicate or a string, got \`${typeof labelOrPredicate}\``);
 	}


### PR DESCRIPTION
This PR fixes #135.

@sindresorhus You pointed to [this block](https://github.com/daliwali/error-class/blob/b1e9193254941ec2a549a40185cc4a05db98d241/index.js#L34-L40) which does

```
if ('captureStackTrace' in Error) {
	Error.captureStackTrace(this, context);
} else {
	this.stack = new Error(message).stack;
}
```

It looks like the `else` clause is moot, no? So I left it out. Let me know if it isn't :).