### PR TITLE
Fix generating dist directory - fixes #143

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -11,7 +11,7 @@ module.exports = {
 	node: false,
 	devtool: 'source-map',
 	output: {
-		path: path.join(__dirname, 'dist'),
+		path: path.join(__dirname, 'dist/source'),
 		filename: 'index.js',
 		libraryTarget: 'commonjs2'
 	},


### PR DESCRIPTION
I wasn't able to generate the everything directly in `dist` so now just generating the bundles in `dist/source`. This is what I believe you wanted to do I guess :).

Fixes #143