### PR TITLE
Move type-fest to dependency list

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,6 +46,9 @@
 		"instanceof",
 		"object"
 	],
+	"dependencies": {
+		"type-fest": "^0.5.1"
+	},
 	"devDependencies": {
 		"@sindresorhus/is": "^0.16.0",
 		"@sindresorhus/tsconfig": "^0.3.0",
@@ -64,7 +67,6 @@
 		"nyc": "^14.1.1",
 		"tslint": "^5.12.0",
 		"tslint-xo": "^0.16.0",
-		"type-fest": "^0.4.1",
 		"typedoc": "^0.14.2",
 		"typescript": "^3.3.1",
 		"vali-date": "^1.0.0",


### PR DESCRIPTION
I noticed that currently you can't use `Ow` if you don't have `type-fest` installed as well because `Ow` depends on it. Because it was a dev dependency, it didn't ship to users causing the compiler to break.