### PR TITLE
Add custom error messages

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -71,13 +71,13 @@ ow(unicorn, ow.object.exactShape({
 
 [Complete API documentation](https://sindresorhus.com/ow)
 
-### ow(value, predicate)
+### ow(value, predicate, [customError])
 
-Test if `value` matches the provided `predicate`. Throws an `ArgumentError` if the test fails.
+Test if `value` matches the provided `predicate`. Throws an `ArgumentError` if the test fails or `customError` if it's specified.
 
-### ow(value, label, predicate)
+### ow(value, label, predicate, [customError])
 
-Test if `value` matches the provided `predicate`. Throws an `ArgumentError` with the specified `label` if the test fails.
+Test if `value` matches the provided `predicate`. Throws an `ArgumentError` with the specified `label` if the test fails or `customError` if it's specified.
 
 The `label` is automatically inferred in Node.js but you can override it by passing in a value for `label`. The automatic label inference doesn't work in the browser.
 
@@ -85,9 +85,9 @@ The `label` is automatically inferred in Node.js but you can override it by pass
 
 Returns `true` if the value matches the predicate, otherwise returns `false`.
 
-### ow.create(predicate)
+### ow.create(predicate, [customError])
 
-Create a reusable validator.
+Create a reusable validator, that throws the `customError` if the test fails.
 
 ```ts
 const checkPassword = ow.create(ow.string.minLength(6));
@@ -98,9 +98,9 @@ checkPassword(password);
 //=> ArgumentError: Expected string `password` to have a minimum length of `6`, got `foo`
 ```
 
-### ow.create(label, predicate)
+### ow.create(label, predicate, [customError])
 
-Create a reusable validator with a specific `label`.
+Create a reusable validator with a specific `label`, that throws the `customError` if the test fails.
 
 ```ts
 const checkPassword = ow.create('password', ow.string.minLength(6));

--- a/source/predicates/any.ts
+++ b/source/predicates/any.ts
@@ -12,7 +12,7 @@ export class AnyPredicate<T = unknown> implements BasePredicate<T> {
 		private readonly options: PredicateOptions = {}
 	) {}
 
-	[testSymbol](value: T, main: Main, label: string | Function) {
+	[testSymbol](value: T, main: Main, label: string | Function, customError?: Error) {
 		const errors = [
 			'Any predicate failed with the following errors:'
 		];
@@ -30,6 +30,10 @@ export class AnyPredicate<T = unknown> implements BasePredicate<T> {
 			}
 		}
 
-		throw new ArgumentError(errors.join('\n'), main);
+		if (customError === undefined) {
+			throw new ArgumentError(errors.join('\n'), main);
+		} else {
+			throw customError;
+		}
 	}
 }

--- a/source/predicates/base-predicate.ts
+++ b/source/predicates/base-predicate.ts
@@ -14,5 +14,5 @@ export const isPredicate = (value: any): value is BasePredicate => Boolean(value
 @hidden
 */
 export interface BasePredicate<T = unknown> {
-	[testSymbol](value: T, main: Main, label: string | Function): void;
+	[testSymbol](value: T, main: Main, label: string | Function, customError?: Error): void;
 }

--- a/source/predicates/predicate.ts
+++ b/source/predicates/predicate.ts
@@ -77,7 +77,7 @@ export class Predicate<T = unknown> implements BasePredicate<T> {
 	/**
 	@hidden
 	*/
-	[testSymbol](value: T, main: Main, label: string | Function) {
+	[testSymbol](value: T, main: Main, label: string | Function, customError?: Error) {
 		for (const {validator, message} of this.context.validators) {
 			if (this.options.optional === true && value === undefined) {
 				continue;
@@ -87,6 +87,10 @@ export class Predicate<T = unknown> implements BasePredicate<T> {
 
 			if (result === true) {
 				continue;
+			}
+
+			if (customError) {
+				throw customError;
 			}
 
 			let label2 = label;

--- a/source/test.ts
+++ b/source/test.ts
@@ -9,6 +9,6 @@ Validate the value against the provided predicate.
 @param label - Label which should be used in error messages.
 @param predicate - Predicate to test to value against.
 */
-export default function test<T>(value: T, label: string | Function, predicate: BasePredicate<T>) {
-	predicate[testSymbol](value, test, label);
+export default function test<T>(value: T, label: string | Function, predicate: BasePredicate<T>, customError?: Error) {
+	predicate[testSymbol](value, test, label, customError);
 }

--- a/test/test.ts
+++ b/test/test.ts
@@ -178,3 +178,31 @@ test('custom validation function', t => {
 		})));
 	}, '(string `unicorn`) Should be `🌈`');
 });
+
+test('validation with custom error', t => {
+	t.throws(() => {
+		ow('foo' as any, ow.number, new Error('custom_error'));
+	}, 'custom_error');
+
+	t.throws(() => {
+		ow('foo' as any, 'custom_label', ow.number, new Error('custom_error'));
+	}, 'custom_error');
+
+	t.throws(() => {
+		const validator = ow.create(ow.number, new Error('custom_error'));
+		validator('foo' as any);
+	}, 'custom_error');
+
+	t.throws(() => {
+		const validator = ow.create('custom_label', ow.number, new Error('custom_error'));
+		validator('foo' as any);
+	}, 'custom_error');
+
+	t.throws(() => {
+		ow('foo', ow.any(ow.string.minLength(4), ow.number), new Error('custom_error'));
+	}, 'custom_error');
+
+	t.throws(() => {
+		ow('foo', 'custom_label', ow.any(ow.string.minLength(4), ow.number), new Error('custom_error'));
+	}, 'custom_error');
+});


### PR DESCRIPTION
Hi!
I implemented custom error messages from issue #122.  
I don't know if it's the right way to do it, but here it is :smile:.  
I've also written a few test for it, and the other tests passed as well.


<!-- Issuehunt content -->

---

<details>
<summary>
<b>IssueHunt Summary</b>
</summary>

### Referenced issues

This pull request has been submitted to:
- [#122: Custom error message](https://issuehunt.io/repos/105227249/issues/122)
---

IssueHunt has been backed by the following sponsors. [Become a sponsor](https://issuehunt.io/membership/members)
</details>
<!-- /Issuehunt content-->