### PR TITLE
Ignore undefined in BasePredicate

### DIFF
--- a/source/predicates/base-predicate.ts
+++ b/source/predicates/base-predicate.ts
@@ -1,5 +1,7 @@
 import {Main} from '..';
 
+type Narrow<T> = T extends undefined ? never : T;
+
 /**
 @hidden
 */
@@ -14,5 +16,5 @@ export const isPredicate = (value: any): value is BasePredicate => Boolean(value
 @hidden
 */
 export interface BasePredicate<T = unknown> {
-	[testSymbol](value: T, main: Main, label: string | Function): void;
+	[testSymbol](value: Narrow<T>, main: Main, label: string | Function): void;
 }


### PR DESCRIPTION
~It fixes #147 by ignoring `undefined` in strict type checking.~
This approach introduces a breaking change and fails some tests... so I close it.