### PR TITLE
Add a `.catching()` method to Predicate to allow nesting ow validators

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -251,13 +251,19 @@ interface Animal {
 }
 
 function validateAnimal(animal: Animal) {
-	ow(animal.type, 'Animal.type', ow.string.oneOf([ 'dog', 'cat', 'elephant' ]));
+	ow(animal.type, 'Animal.type', ow.string.oneOf(['dog', 'cat', 'elephant']));
 	ow(animal.weight, 'Animal.weight', ow.number.finite.positive);
 }
 
 const animals: Animal [] = [
-	{ type: 'dog', weight: 5 },
-	{ type: 'cat', weight: Number.POSITIVE_INFINITY }
+	{
+		type: 'dog',
+		weight: 5
+	},
+	{
+		type: 'cat',
+		weight: Number.POSITIVE_INFINITY
+	}
 ];
 
 ow(animals, ow.array.ofType(ow.object.catching(animal => validateAnimal(animal as Animal))));

--- a/readme.md
+++ b/readme.md
@@ -240,6 +240,29 @@ ow(1, 'input', ow.number.validate(value => ({
 
 This can be useful for creating your own reusable validators which can be extracted to a separate npm package.
 
+#### catching(fn)
+
+Use a custom validation function that throws error. The function should throw an error if value is invalid or return nothing when value is valid. This allows to use specific validators for complex property or array types.
+
+```ts
+interface Animal {
+	type: string;
+	weight: number;
+}
+
+function validateAnimal(animal: Animal) {
+	ow(animal.type, 'Animal.type', ow.string.oneOf([ 'dog', 'cat', 'elephant' ]));
+	ow(animal.weight, 'Animal.weight', ow.number.finite.positive);
+}
+
+const animals: Animal [] = [
+	{ type: 'dog', weight: 5 },
+	{ type: 'cat', weight: Number.POSITIVE_INFINITY }
+];
+
+ow(animals, ow.array.ofType(ow.object.catching(animal => validateAnimal(animal as Animal))));
+//=> ArgumentError: (array `animals`) (object) Expected number `Animal.weight` to be finite, got Infinity
+```
 
 ## Maintainers
 

--- a/source/predicates/any.ts
+++ b/source/predicates/any.ts
@@ -1,7 +1,7 @@
 import {ArgumentError} from '../argument-error';
 import {BasePredicate, testSymbol} from './base-predicate';
-import {Main} from '..';
 import {PredicateOptions} from './predicate';
+import {Main} from '..';
 
 /**
 @hidden

--- a/source/predicates/array.ts
+++ b/source/predicates/array.ts
@@ -1,6 +1,6 @@
 import isEqual = require('lodash.isequal');
-import ow from '..';
 import {Predicate, PredicateOptions} from './predicate';
+import ow from '..';
 
 export class ArrayPredicate<T = unknown> extends Predicate<T[]> {
 	/**

--- a/source/predicates/predicate.ts
+++ b/source/predicates/predicate.ts
@@ -168,6 +168,7 @@ export class Predicate<T = unknown> implements BasePredicate<T> {
 				return error.message;
 			}
 		};
+
 		return this.is(validator);
 	}
 

--- a/source/predicates/predicate.ts
+++ b/source/predicates/predicate.ts
@@ -156,6 +156,22 @@ export class Predicate<T = unknown> implements BasePredicate<T> {
 	}
 
 	/**
+	 * Test if the value matches a custom validation function. The validation should throw an error if the value does not pass the validation. It allows to stack multiple ow() checks, eg. can be used to validate a subtype with ow functions.
+	 * @param throwingValidator — Validation function that throws an error
+	 */
+	catching(throwingValidator: (value: T) => void) {
+		const validator = (value: T) => {
+			try {
+				throwingValidator(value);
+				return true;
+			} catch (error) {
+				return error.message;
+			}
+		};
+		return this.is(validator);
+	}
+
+	/**
 	Register a new validator.
 
 	@param validator - Validator to register.

--- a/source/predicates/predicate.ts
+++ b/source/predicates/predicate.ts
@@ -1,8 +1,8 @@
 import is from '@sindresorhus/is';
 import {ArgumentError} from '../argument-error';
-import {Main} from '..';
 import {not} from '../operators/not';
 import {BasePredicate, testSymbol} from './base-predicate';
+import {Main} from '..';
 
 /**
 @hidden

--- a/source/utils/match-shape.ts
+++ b/source/utils/match-shape.ts
@@ -1,7 +1,7 @@
 import is from '@sindresorhus/is';
-import {BasePredicate} from '..';
 import test from '../test';
 import {isPredicate} from '../predicates/base-predicate';
+import {BasePredicate} from '..';
 
 export interface Shape {
 	[key: string]: BasePredicate | Shape;

--- a/source/utils/of-type-deep.ts
+++ b/source/utils/of-type-deep.ts
@@ -1,6 +1,6 @@
 import is from '@sindresorhus/is';
-import ow from '..';
 import {Predicate} from '../predicates/predicate';
+import ow from '..';
 
 const ofTypeDeep = (object: any, predicate: Predicate): boolean => {
 	if (!is.plainObject(object)) {

--- a/source/utils/of-type.ts
+++ b/source/utils/of-type.ts
@@ -1,5 +1,5 @@
-import ow from '..';
 import {Predicate} from '../predicates/predicate';
+import ow from '..';
 
 /**
 Test all the values in the collection against a provided predicate.

--- a/test/test.ts
+++ b/test/test.ts
@@ -82,7 +82,9 @@ test('is', t => {
 
 test('catching', t => {
 	t.throws(() => {
-		ow('1', ow.string.catching(() => { throw new Error('Error in a throwing validator'); }));
+		ow('1', ow.string.catching(() => {
+			throw new Error('Error in a throwing validator');
+		}));
 	}, '(string) Error in a throwing validator');
 
 	t.throws(() => {
@@ -94,8 +96,8 @@ test('catching', t => {
 		};
 
 		const arrayOfNumbers: SpecificType [] = [
-			{ x: 1 },
-			{ x: Number.POSITIVE_INFINITY }
+			{x: 1},
+			{x: Number.POSITIVE_INFINITY}
 		];
 		ow(arrayOfNumbers, ow.array.ofType(ow.object.catching(o => nestedOwValidator(o as SpecificType))));
 	}, '(array `arrayOfNumbers`) (object) Expected number `value.x` to be finite, got Infinity');

--- a/test/test.ts
+++ b/test/test.ts
@@ -82,7 +82,7 @@ test('is', t => {
 
 test('catching', t => {
 	t.throws(() => {
-		ow('1', ow.string.catch(() => { throw new Error('Error in a throwing validator'); }));
+		ow('1', ow.string.catching(() => { throw new Error('Error in a throwing validator'); }));
 	}, '(string) Error in a throwing validator');
 
 	t.throws(() => {

--- a/test/test.ts
+++ b/test/test.ts
@@ -80,6 +80,27 @@ test('is', t => {
 	}, '(number `foo`) Expected `5` to be greater than `10`');
 });
 
+test('catching', t => {
+	t.throws(() => {
+		ow('1', ow.string.catch(() => { throw new Error('Error in a throwing validator'); }));
+	}, '(string) Error in a throwing validator');
+
+	t.throws(() => {
+		interface SpecificType {
+			x: number;
+		}
+		const nestedOwValidator = (value: SpecificType) => {
+			ow(value.x, ow.number.finite);
+		};
+
+		const arrayOfNumbers: SpecificType [] = [
+			{ x: 1 },
+			{ x: Number.POSITIVE_INFINITY }
+		];
+		ow(arrayOfNumbers, ow.array.ofType(ow.object.catching(o => nestedOwValidator(o as SpecificType))));
+	}, '(array `arrayOfNumbers`) (object) Expected number `value.x` to be finite, got Infinity');
+});
+
 test('isValid', t => {
 	t.true(ow.isValid(1, ow.number));
 	t.true(ow.isValid(1, ow.number.equal(1)));


### PR DESCRIPTION
I love ow and use it heavily in my TS projects. I use a pattern in which I create a validator function for my interfaces. This validator function uses multiple ow calls to guard the properties. Often an interface is used as a type of a property inside another interface, and that interface also has a validator. It would be very handful if I could just validate this specific property against an already defined validator. Speaking code my pull request allows to do the following:

```typescript
import ow from "ow";
import { PublishableOperation } from "./PublishableOperation";

export interface PublishJob {
    ops: PublishableOperation[];
    delegator: string;
}

export namespace PublishJob {
    export function validate(job: PublishJob) {
        ow(
            job.ops,
            "job.ops",
            ow.array
                .ofType(ow.object.catching(o => PublishableOperation.validate(o as PublishableOperation))),
        );
        ...
    }
}
```
This is a way I am achiving it now: https://github.com/wise-team/wise-hub/blob/b0ef49a78ff51e3c8a866513a7d13a68d4b8959a/backend/src/publisher/entities/PublishJob.ts My pull request allows the above way which is far more clean and readable. Of course I've added unit tests for the feature. 

I named the method `.catching()` because it simply catches errors. Also, 'catch' is a keyword and I was not sure it is safe to use it in a property-method context. I am not sure If it is the best name.

I am really looking forward to use this feature!

Thank you in advance,
Jędrzej