### PR TITLE
Add invert modifier for all predicates

### DIFF
--- a/source/modifiers.ts
+++ b/source/modifiers.ts
@@ -5,12 +5,21 @@ export interface Modifiers {
 	Make the following predicate optional so it doesn't fail when the value is `undefined`.
 	*/
 	readonly optional: Predicates;
+
+	/**
+	Make the following predicate inverted.
+	*/
+	readonly not: Predicates;
 }
 
 export default <T>(object: T): T & Modifiers => {
 	Object.defineProperties(object, {
 		optional: {
 			get: () => predicates({}, {optional: true})
+		},
+
+		not: {
+			get: () => predicates({}, {invert: true})
 		}
 	});
 

--- a/source/predicates/predicate.ts
+++ b/source/predicates/predicate.ts
@@ -18,6 +18,7 @@ export interface Validator<T> {
 */
 export interface PredicateOptions {
 	optional?: boolean;
+	invert?: boolean;
 }
 
 /**
@@ -68,7 +69,11 @@ export class Predicate<T = unknown> implements BasePredicate<T> {
 				// We do not include type in this label as we do for other messages, because it would be redundant.
 				const lbl = label && label.substring(this.type.length + 1);
 
-				return `Expected ${lbl || 'argument'} to be of type \`${this.type}\` but received type \`${is(value)}\``;
+				if (options.invert) {
+					return `Expected ${lbl || 'argument'}${options.invert ? ' not' : ''} to be of type \`${this.type}\``;
+				}
+
+				return `Expected ${lbl || 'argument'}${options.invert ? ' not' : ''} to be of type \`${this.type}\` but received type \`${is(value)}\``;
 			},
 			validator: value => (is as any)[x](value)
 		});
@@ -83,7 +88,11 @@ export class Predicate<T = unknown> implements BasePredicate<T> {
 				continue;
 			}
 
-			const result = validator(value);
+			let result = validator(value);
+
+			if (is.boolean(result) && this.options.invert) {
+				result = !result;
+			}
 
 			if (result === true) {
 				continue;

--- a/test/invert.ts
+++ b/test/invert.ts
@@ -1,0 +1,28 @@
+import test from 'ava';
+import ow from '../source';
+
+test('inverted', t => {
+	t.throws(() => {
+		ow(1, ow.not.number);
+	}, 'Expected argument not to be of type `number`');
+
+	t.throws(() => {
+		ow(undefined, ow.not.undefined);
+	}, 'Expected argument not to be of type `undefined`');
+
+	t.throws(() => {
+		ow(undefined, ow.any(ow.not.undefined, ow.string));
+	});
+
+	t.notThrows(() => {
+		ow(1, ow.any(ow.not.undefined, ow.number));
+	});
+
+	t.notThrows(() => {
+		ow('1', ow.not.undefined);
+	});
+
+	t.notThrows(() => {
+		ow(1, ow.not.undefined);
+	});
+});


### PR DESCRIPTION
Hi guys,

this PR add `not` modifier to all predicates and should fix #148
```
// Chain from any predicate instance
ow('2', ow.any(ow.not.number, ow.not.string.numeric))

// Chain from any predicate rule(because it the same predicate instance)
ow(undefined, ow.not.undefined)
```