### PR TITLE
Fix eslint errors and warnings

### DIFF
--- a/source/argument-error.ts
+++ b/source/argument-error.ts
@@ -6,6 +6,7 @@ export class ArgumentError extends Error {
 		super(message);
 
 		if (Error.captureStackTrace) {
+			/* eslint-disable-next-line no-warning-comments */
 			// TODO: Node.js does not preserve the error name in output when using the below, why?
 			Error.captureStackTrace(this, context);
 		} else {

--- a/source/predicates/object.ts
+++ b/source/predicates/object.ts
@@ -156,6 +156,7 @@ export class ObjectPredicate extends Predicate<object> {
 	*/
 	partialShape(shape: Shape) {
 		return this.addValidator({
+			/* eslint-disable-next-line no-warning-comments */
 			// TODO: Improve this when message handling becomes smarter
 			message: (_, label, message) => `${message.replace('Expected', 'Expected property')} in ${label}`,
 			validator: object => partial(object, shape)
@@ -180,6 +181,7 @@ export class ObjectPredicate extends Predicate<object> {
 	*/
 	exactShape(shape: Shape) {
 		return this.addValidator({
+			/* eslint-disable-next-line no-warning-comments */
 			// TODO: Improve this when message handling becomes smarter
 			message: (_, label, message) => `${message.replace('Expected', 'Expected property')} in ${label}`,
 			validator: object => exact(object, shape)

--- a/source/predicates/predicate.ts
+++ b/source/predicates/predicate.ts
@@ -107,6 +107,7 @@ export class Predicate<T = unknown> implements BasePredicate<T> {
 				`${this.type} \`${label2}\`` :
 				this.type;
 
+			/* eslint-disable-next-line no-warning-comments */
 			// TODO: Modify the stack output to show the original `ow()` call instead of this `throw` statement
 			throw new ArgumentError(message(value, label2, result), main);
 		}

--- a/source/utils/infer-label.browser.ts
+++ b/source/utils/infer-label.browser.ts
@@ -1,4 +1,5 @@
 // Dummy in the browser.
+/* eslint-disable-next-line @typescript-eslint/no-empty-function */
 export const inferLabel = () => {
 
 };

--- a/test/function.ts
+++ b/test/function.ts
@@ -3,6 +3,7 @@ import ow from '../source';
 
 test('function', t => {
 	t.notThrows(() => {
+		/* eslint-disable-next-line @typescript-eslint/no-empty-function */
 		ow(() => {}, ow.function);
 	});
 


### PR DESCRIPTION
This PR removes ESLint warnings using `/* eslint-disable-next-line ... */`. The errors and warnings removed were explicitly created, thus there is no need to display them in linter report.