### PR TITLE
Fix the logo in the docs

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -26,6 +26,7 @@
 		"suppressImplicitAnyIndexErrors": true,
 		"theme": "minimal",
 		"hideGenerator": true,
-		"readme": "readme.md"
+		"readme": "readme.md",
+		"media": "media"
 	}
 }


### PR DESCRIPTION
The logo is not rendering at [sindresorhus.com/ow](https://sindresorhus.com/ow/).  

This PR updates the TypeDoc config to copy all media assets to the distribution folder. 

**Before:**
![image](https://user-images.githubusercontent.com/4730164/75121092-d80f0900-565e-11ea-9189-08ded8ae0081.png)

**After:**
![image](https://user-images.githubusercontent.com/4730164/75121121-1c9aa480-565f-11ea-85bb-1835ddad5ca5.png)
