### PR TITLE
Add method to return the error without throwing

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -107,6 +107,30 @@ checkPassword('foo');
 //=> ArgumentError: Expected string `password` to have a minimum length of `6`, got `foo`
 ```
 
+### ow.validate(predicate)
+
+Create a reusable validator. It returns error and value.
+
+```ts
+const checkPassword = ow.validate(ow.string.minLength(6));
+
+const password = 'foo';
+
+const {error, value} = checkPassword(password);
+//=> ArgumentError: Expected string `password` to have a minimum length of `6`, got `foo`
+```
+
+### ow.createValidate(label, predicate)
+
+Create a reusable validator with a specific `label`. It returns error and value.
+
+```ts
+const checkPassword = ow.createValidate('password', ow.string.minLength(6));
+
+const {error, value} = checkPassword('foo');
+//=> ArgumentError: Expected string `password` to have a minimum length of `6`, got `foo`
+```
+
 ### ow.any(...predicate[])
 
 Returns a predicate that verifies if the value matches at least one of the given predicates.

--- a/source/index.ts
+++ b/source/index.ts
@@ -52,6 +52,38 @@ export interface Ow extends Modifiers, Predicates {
 	@param predicate - Predicate used in the validator function.
 	*/
 	create<T>(label: string, predicate: BasePredicate<T>): ReusableValidator<T>;
+
+	/**
+	Test if the value matches the predicate. It returns error and value.
+
+	@param value - Value to test.
+	@param predicate - Predicate to test against.
+	*/
+	validate<T>(value: T, predicate: BasePredicate<T>): {error: Error | null; value: T};
+
+	/**
+	Test if the value matches the predicate. It returns error and value.
+
+	@param value - Value to test.
+	@param label - Label which should be used in error messages.
+	@param predicate - Predicate to test against.
+	*/
+	validate<T>(value: T, label: string, predicate: BasePredicate<T>): {error: Error | null; value: T};
+
+	/**
+	Create a reusable validator. It returns error, It ReusableValidator returns error.
+
+	@param predicate - Predicate to test against.
+	*/
+	createValidate<T>(predicate: BasePredicate<T>): (value: T, label?: string) => {error: Error | null; value: T};
+
+	/**
+	Create a reusable validator. It returns error, It ReusableValidator returns error.
+
+	@param label - Label which should be used in error messages.
+	@param predicate - Predicate to test against.
+	*/
+	createValidate<T>(label: string, predicate: BasePredicate<T>): (value: T, label?: string) => {error: Error | null; value: T};
 }
 
 /**
@@ -107,6 +139,40 @@ Object.defineProperties(ow, {
 			}
 
 			test(value, label ?? (labelOrPredicate as string), predicate as BasePredicate<T>);
+		}
+	},
+	validate: {
+		value: <T>(value: T, labelOrPredicate: unknown, predicate?: BasePredicate<T>) => {
+			try {
+				ow(value, labelOrPredicate, predicate);
+
+				return {
+					error: null,
+					value
+				};
+			} catch (error) {
+				return {
+					error,
+					value
+				};
+			}
+		}
+	},
+	createValidate: {
+		value: <T>(labelOrPredicate: BasePredicate<T> | string | undefined, predicate?: BasePredicate<T>) => (value: T, label?: string) => {
+			try {
+				ow(value, label ?? labelOrPredicate, predicate);
+
+				return {
+					error: null,
+					value
+				};
+			} catch (error) {
+				return {
+					error,
+					value
+				};
+			}
 		}
 	}
 });

--- a/test/test.ts
+++ b/test/test.ts
@@ -279,8 +279,37 @@ test('isValid', t => {
 	t.false(ow.isValid(true as any, ow.any(ow.string, ow.number)));
 });
 
+test('validate', t => {
+	const valueCauseError = 1 as any as string;
+
+	t.notThrows(() => {
+		const {error, value} = ow.validate('foo', ow.string);
+		t.true(error === null);
+		t.true(value === 'foo');
+	});
+
+	t.notThrows(() => {
+		const {error, value} = ow.validate('foo', 'label', ow.string);
+		t.true(error === null);
+		t.true(value === 'foo');
+	});
+
+	t.notThrows(() => {
+		const {error, value} = ow.validate(valueCauseError, ow.string);
+		t.true(error instanceof Error);
+		t.true(value === valueCauseError);
+	});
+
+	t.notThrows(() => {
+		const {error, value} = ow.validate(valueCauseError, 'label', ow.string);
+		t.true(error instanceof Error);
+		t.true(value === valueCauseError);
+	});
+});
+
 test('reusable validator', t => {
 	const checkUsername = ow.create(ow.string.minLength(3));
+	const checkNickname = ow.createValidate('nickname', ow.string.minLength(3));
 
 	const value = 'x';
 
@@ -303,6 +332,18 @@ test('reusable validator', t => {
 	t.throws(() => {
 		checkUsername(5 as any);
 	}, 'Expected argument to be of type `string` but received type `number`');
+
+	t.notThrows(() => {
+		const {error, value} = checkNickname('foo');
+		t.true(error === null);
+		t.true(value === 'foo');
+	});
+
+	t.notThrows(() => {
+		const {error, value} = checkNickname('fo');
+		t.true(error instanceof Error);
+		t.true(value === 'fo');
+	});
 });
 
 test('reusable validator called with label', t => {


### PR DESCRIPTION
Hi, the project joi has API validate it returns {error, value} such as:

```ts
let schema = Joi.string().empty('');
schema.validate(''); // returns { error: null, value: undefined }

schema = schema.empty();
schema.validate(''); // returns { error: "value" is not allowed to be empty, value: '' }
```

Or `.error(new Error(...))`

```ts
const schema = Joi.string()
  .error(new Error('Was REALLY expecting a string'));

schema.validate(3);
// returns Error('Was REALLY expecting a string')
```

So I make API `validate` and `createValidate` it also returns {error, value}.

What do you think?

Fixes #169