### PR TITLE
Allow potentially undefined functions to be checked

### DIFF
--- a/source/predicates/predicate.ts
+++ b/source/predicates/predicate.ts
@@ -86,13 +86,15 @@ export class Predicate<T = unknown> implements BasePredicate<T> {
 	/**
 	@hidden
 	*/
-	[testSymbol](value: T, main: Main, label: string | Function): asserts value {
+	[testSymbol](value: T | undefined, main: Main, label: string | Function): asserts value {
 		for (const {validator, message} of this.context.validators) {
 			if (this.options.optional === true && value === undefined) {
 				continue;
 			}
-
-			const result = validator(value);
+			
+			const knownValue = value as T;
+			
+			const result = validator(knownValue);
 
 			if (result === true) {
 				continue;
@@ -109,7 +111,7 @@ export class Predicate<T = unknown> implements BasePredicate<T> {
 				this.type;
 
 			// TODO: Modify the stack output to show the original `ow()` call instead of this `throw` statement
-			throw new ArgumentError(message(value, label2, result), main);
+			throw new ArgumentError(message(knownValue, label2, result), main);
 		}
 	}
 

--- a/source/predicates/predicate.ts
+++ b/source/predicates/predicate.ts
@@ -91,9 +91,9 @@ export class Predicate<T = unknown> implements BasePredicate<T> {
 			if (this.options.optional === true && value === undefined) {
 				continue;
 			}
-			
+
 			const knownValue = value as T;
-			
+
 			const result = validator(knownValue);
 
 			if (result === true) {

--- a/source/predicates/predicate.ts
+++ b/source/predicates/predicate.ts
@@ -92,7 +92,7 @@ export class Predicate<T = unknown> implements BasePredicate<T> {
 				continue;
 			}
 
-			const knownValue = value as T;
+			const knownValue = value!;
 
 			const result = validator(knownValue);
 

--- a/test/optional.ts
+++ b/test/optional.ts
@@ -18,6 +18,18 @@ test('optional', t => {
 		ow(undefined, ow.optional.any(ow.string, ow.number));
 	});
 
+	t.notThrows(() => {
+		ow(undefined, ow.optional.function);
+	});
+
+	t.notThrows(() => {
+		ow((() => {}) as any as ((() => void) | undefined), ow.optional.function);
+	});
+
+	t.throws(() => {
+		ow(null, ow.optional.function);
+	}, 'Expected argument to be of type `Function` but received type `null`');
+
 	t.throws(() => {
 		ow(null, ow.optional.number);
 	}, 'Expected argument to be of type `number` but received type `null`');


### PR DESCRIPTION
proposed changes to fix #147


<!-- Issuehunt content -->

---

<details>
<summary>
<b>IssueHunt Summary</b>
</summary>

### Referenced issues

This pull request has been submitted to:
- [#147: TypeScript optional function argument throws error TS2345 with `ow.optional.function`](https://issuehunt.io/repos/105227249/issues/147)
---
</details>
<!-- /Issuehunt content-->