### PR TITLE
Adding note about use with webpack for the browser

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -274,6 +274,18 @@ ow(
 
 This can be useful for creating your own reusable validators which can be extracted to a separate npm package.
 
+## Use with Webpack
+To use ow in a browser environment with webpack. You will need to tell webpack to provide an empty implementation of the built in node library 'fs'. You can add this option to your webpack config to allow it to compile properly.
+
+```js
+module.exports = {
+  // ...
+  node: {
+    fs: 'empty'
+  }
+}
+```
+
 ## Maintainers
 
 - [Sindre Sorhus](https://github.com/sindresorhus)


### PR DESCRIPTION
My team recently implemented ow in a browser app we are writing. We struggled to get everything working with webpack but eventually came across this config that allowed us to safely compile. Hoping this small addition can save others the pain of implementing this library in a browser app.

I believe this should also be a fix for [this issue](https://github.com/sindresorhus/ow/issues/160).