### PR TITLE
Add `method` helper

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -119,6 +119,19 @@ checkPassword('foo');
 //=> ArgumentError: Expected string `password` to have a minimum length of `6`, got `foo`
 ```
 
+### ow.method(predicates, label, body)
+
+Wrap a function with parameter validation. Useful for writing strongly typed functions which will be called with untrusted input.
+
+```ts
+const add = ow.method([ow.number, ow.number], (a, b) => a + b);
+
+add(1, 2) // returns 3
+
+add(1, '3')
+// => ArgumentError: 'Expected element `1` to be of type `number` but received type `string` in array `parameters`'
+```
+
 ### ow.any(...predicate[])
 
 Returns a predicate that verifies if the value matches at least one of the given predicates.

--- a/readme.md
+++ b/readme.md
@@ -121,15 +121,16 @@ checkPassword('foo');
 
 ### ow.method(predicates, label, body)
 
-Wrap a function with parameter validation. Useful for writing strongly typed functions which will be called with untrusted input.
+Wrap a function with parameter validation. Useful for writing strongly-typed functions which will be called with untrusted input.
 
 ```ts
 const add = ow.method([ow.number, ow.number], (a, b) => a + b);
 
-add(1, 2) // returns 3
+add(1, 2);
+//=> 3
 
-add(1, '3')
-// => ArgumentError: 'Expected element `1` to be of type `number` but received type `string` in array `parameters`'
+add(1, '3');
+//=> ArgumentError: 'Expected element `1` to be of type `number` but received type `string` in array `parameters`'
 ```
 
 ### ow.any(...predicate[])

--- a/source/index.ts
+++ b/source/index.ts
@@ -55,9 +55,9 @@ export interface Ow extends Modifiers, Predicates {
 	add(1, 'foo') // throws 'Expected element `1` to be of type `number` but received type `string` in array'
 	```
 	 */
-	method<Predicates extends Tuple<BasePredicate<any>>, Return>(
-		predicates: Predicates,
-		body: (...args: Extract<{ [K in keyof Predicates]: Predicates[K] extends BasePredicate<infer X> ? X : never }, any[]>) => Return
+	method<Params extends Tuple<any>, Return>(
+		predicates: Extract<{ [K in keyof Params]: BasePredicate<Params[K]> }, any[]>,
+		body: (...args: Params) => Return
 	): typeof body;
 
 	/**
@@ -77,10 +77,10 @@ export interface Ow extends Modifiers, Predicates {
 	add(1, 'foo') // throws 'Expected element `1` to be of type `number` but received type `string` in array'
 	```
 	 */
-	method<Predicates extends Tuple<BasePredicate<any>>, Return>(
-		predicates: Predicates,
+	method<Params extends Tuple<any>, Return>(
+		predicates: Extract<{ [K in keyof Params]: BasePredicate<Params[K]> }, any[]>,
 		functionName: string,
-		body: (...args: Extract<{ [K in keyof Predicates]: Predicates[K] extends BasePredicate<infer X> ? X : never }, any[]>) => Return
+		body: (...args: Params) => Return
 	): typeof body;
 
 	/**

--- a/source/index.ts
+++ b/source/index.ts
@@ -55,9 +55,9 @@ export interface Ow extends Modifiers, Predicates {
 	add(1, 'foo') // throws 'Expected element `1` to be of type `number` but received type `string` in array'
 	```
 	 */
-	method<Params extends Tuple<any>, Return>(
-		predicates: Extract<{ [K in keyof Params]: BasePredicate<Params[K]> }, any[]>,
-		body: (...args: Params) => Return
+	method<Arguments extends Tuple<any>, Return>(
+		predicates: Extract<{ [K in keyof Arguments]: BasePredicate<Arguments[K]> }, any[]>,
+		body: (...args: Arguments) => Return
 	): typeof body;
 
 	/**
@@ -77,10 +77,10 @@ export interface Ow extends Modifiers, Predicates {
 	add(1, 'foo') // throws 'Expected element `1` to be of type `number` but received type `string` in array'
 	```
 	 */
-	method<Params extends Tuple<any>, Return>(
-		predicates: Extract<{ [K in keyof Params]: BasePredicate<Params[K]> }, any[]>,
+	method<Arguments extends Tuple<any>, Return>(
+		predicates: Extract<{ [K in keyof Arguments]: BasePredicate<Arguments[K]> }, any[]>,
 		functionName: string,
-		body: (...args: Params) => Return
+		body: (...args: Arguments) => Return
 	): typeof body;
 
 	/**

--- a/source/index.ts
+++ b/source/index.ts
@@ -12,7 +12,7 @@ import test from './test';
 export type Main = <T>(value: T, label: string | Function, predicate: BasePredicate<T>) => void;
 
 // Helper type - when a typearg extends this, the function allows usage only with tuples, as opposed to arrays.
-type Tuple<T> = 
+type Tuple<T> =
 	| [T]
 	| [T, T]
 	| [T, T, T]
@@ -20,7 +20,7 @@ type Tuple<T> =
 	| [T, T, T, T, T]
 	| [T, T, T, T, T, T]
 	| [T, T, T, T, T, T, T]
-	| [T, T, T, T, T, T, T, T]
+	| [T, T, T, T, T, T, T, T];
 
 // Extends is only necessary for the generated documentation to be cleaner. The loaders below infer the correct type.
 export interface Ow extends Modifiers, Predicates {
@@ -58,9 +58,8 @@ export interface Ow extends Modifiers, Predicates {
 	method<Predicates extends Tuple<BasePredicate<any>>, Return>(
 		predicates: Predicates,
 		body: (...args: Extract<{ [K in keyof Predicates]: Predicates[K] extends BasePredicate<infer X> ? X : never }, any[]>) => Return
-	): typeof body
+	): typeof body;
 
-	
 	/**
 	Wrap a function with parameter validation. Useful for writing strongly typed functions which will be called with
 	untrusted input.
@@ -82,7 +81,7 @@ export interface Ow extends Modifiers, Predicates {
 		predicates: Predicates,
 		functionName: string,
 		body: (...args: Extract<{ [K in keyof Predicates]: Predicates[K] extends BasePredicate<infer X> ? X : never }, any[]>) => Return
-	): typeof body
+	): typeof body;
 
 	/**
 	Test if the value matches the predicate. Throws an `ArgumentError` if the test fails.
@@ -163,19 +162,19 @@ Object.defineProperties(ow, {
 			functionNameOrBody: string | Function,
 			bodyOrUndefined: Function | undefined
 		) => {
-				const {functionName, body} = typeof functionNameOrBody === 'string'
-					? {functionName: functionNameOrBody, body: bodyOrUndefined as Function}
-					: {functionName: functionNameOrBody.name, body: functionNameOrBody}
+			const {functionName, body} = typeof functionNameOrBody === 'string' ?
+				{functionName: functionNameOrBody, body: bodyOrUndefined!} :
+				{functionName: functionNameOrBody.name, body: functionNameOrBody};
 
-				const label = functionName ? `${functionName}:parameters` : 'parameters'
+			const label = functionName ? `${functionName}:parameters` : 'parameters';
 
-				const argArrayType = _ow.array.exactShape(predicates)
+			const argArrayType = _ow.array.exactShape(predicates);
 
-				return (...args: unknown[]) => {
-					_ow(args, label, argArrayType)
-					return body(...args)
-				}
-			}
+			return (...args: unknown[]) => {
+				_ow(args, label, argArrayType);
+				return body(...args);
+			};
+		}
 	}
 });
 

--- a/source/index.ts
+++ b/source/index.ts
@@ -11,7 +11,7 @@ import test from './test';
 */
 export type Main = <T>(value: T, label: string | Function, predicate: BasePredicate<T>) => void;
 
-// Helper type - when a typearg extends this, the function allows usage only with tuples, as opposed to arrays.
+// Helper type: When a type parameter extends this, the function allows usage only with tuples, as opposed to arrays.
 type Tuple<T> =
 	| [T]
 	| [T, T]
@@ -40,45 +40,51 @@ export interface Ow extends Modifiers, Predicates {
 	create: (<T>(predicate: BasePredicate<T>) => ReusableValidator<T>) & (<T>(label: string, predicate: BasePredicate<T>) => ReusableValidator<T>);
 
 	/**
-	Wrap a function with parameter validation. Useful for writing strongly typed functions which will be called with
+	Wrap a function with parameter validation. Useful for writing strongly-typed functions which will be called with
 	untrusted input.
 
-	@param predicates - Tuple of predicates, corresponding to arguments the function will receive.
+	@param predicates - Tuple of predicates, corresponding to the arguments the function will receive.
 	@param body - The function implementation.
 	@returns A function with the same type as `body`, but at runtime will first validate the argument list against `predicates`.
 
 	@example
 	```
-	const add = ow.method([ow.number, ow.number], (a, b) => a + b)
+	const add = ow.method([ow.number, ow.number], (a, b) => a + b);
 
-	add(1, 2) // returns 3
-	add(1, 'foo') // throws 'Expected element `1` to be of type `number` but received type `string` in array'
+	add(1, 2);
+	//=> 3
+
+	add(1, '3');
+	//=> ArgumentError: 'Expected element `1` to be of type `number` but received type `string` in array `parameters`'
 	```
-	 */
+	*/
 	method<Arguments extends Tuple<any>, Return>(
-		predicates: Extract<{ [K in keyof Arguments]: BasePredicate<Arguments[K]> }, any[]>,
+		predicates: Extract<{[K in keyof Arguments]: BasePredicate<Arguments[K]>}, any[]>,
 		body: (...args: Arguments) => Return
 	): typeof body;
 
 	/**
-	Wrap a function with parameter validation. Useful for writing strongly typed functions which will be called with
+	Wrap a function with parameter validation. Useful for writing strongly-typed functions which will be called with
 	untrusted input.
 
-	@param predicates - Tuple of predicates, corresponding to arguments the function will receive.
+	@param predicates - Tuple of predicates, corresponding to the arguments the function will receive.
 	@param functionName - A name or label for the function whose arguments will be validated. This will appear in any assertion error messages.
 	@param body - The function implementation.
 	@returns A function with the same type as `body`, but at runtime will first validate the argument list against `predicates`.
 
 	@example
 	```
-	const add = ow.method([ow.number, ow.number], 'add', (a, b) => a + b)
+	const add = ow.method([ow.number, ow.number], (a, b) => a + b);
 
-	add(1, 2) // returns 3
-	add(1, 'foo') // throws 'Expected element `1` to be of type `number` but received type `string` in array'
+	add(1, 2);
+	//=> 3
+
+	add(1, '3');
+	//=> ArgumentError: 'Expected element `1` to be of type `number` but received type `string` in array `parameters`'
 	```
-	 */
+	*/
 	method<Arguments extends Tuple<any>, Return>(
-		predicates: Extract<{ [K in keyof Arguments]: BasePredicate<Arguments[K]> }, any[]>,
+		predicates: Extract<{[K in keyof Arguments]: BasePredicate<Arguments[K]>}, any[]>,
 		functionName: string,
 		body: (...args: Arguments) => Return
 	): typeof body;

--- a/source/predicates/array.ts
+++ b/source/predicates/array.ts
@@ -172,7 +172,7 @@ export class ArrayPredicate<T = unknown> extends Predicate<T[]> {
 	ow(['1', 2], ow.array.exactShape([ow.string, ow.number]));
 	```
 	*/
-	exactShape(predicates: Predicate[]) {
+	exactShape(predicates: BasePredicate[]) {
 		const shape = predicates as unknown as Shape;
 
 		return this.addValidator({

--- a/test/method.ts
+++ b/test/method.ts
@@ -1,0 +1,30 @@
+import test from 'ava';
+import ow from '../source';
+
+test('method', t => {
+	const add = ow.method([ow.number, ow.number], (a, b) => a + b);
+
+	t.is(add(2, 2), 4);
+
+	t.throws(() => {
+		add('2' as any, 2);
+	}, 'Expected element `0` to be of type `number` but received type `string` in array `parameters`');
+
+	t.throws(() => {
+		add(2, '2' as any);
+	}, 'Expected element `1` to be of type `number` but received type `string` in array `parameters`');
+});
+
+test('method with label', t => {
+	const add = ow.method([ow.number, ow.number], 'plus', (a, b) => a + b);
+
+	t.is(add(2, 2), 4);
+
+	t.throws(() => {
+		add('2' as any, 2);
+	}, 'Expected element `0` to be of type `number` but received type `string` in array `plus:parameters`');
+
+	t.throws(() => {
+		add(2, '2' as any);
+	}, 'Expected element `1` to be of type `number` but received type `string` in array `plus:parameters`');
+});

--- a/test/types.ts
+++ b/test/types.ts
@@ -106,12 +106,16 @@ function typeTests(value: unknown) {
 			// @ts-expect-error
 			add(1)
 
-			const plus = ow.method([ow.number, ow.number], 'plus', (a, b) => a + b)
+			const exclaim = ow.method([ow.string, ow.number.integer], 'exclaim', (text, enthusiasm) => {
+				expectTypeOf(text).toBeString()
+				expectTypeOf(enthusiasm).toBeNumber()
+				return text + '!'.repeat(enthusiasm)
+			})
 
-			plus(1, 2)
+			exclaim('foo', 2)
 
 			// @ts-expect-error
-			plus(1, 'foo')
+			exclaim('foo', 'bar')
 
 			// @ts-expect-error (argument `c` unexpected)
 			ow.method([ow.number, ow.number], (a, b, c) => a + b + c)

--- a/test/types.ts
+++ b/test/types.ts
@@ -90,11 +90,46 @@ function typeTests(value: unknown) {
 		},
 
 		() => {
+			const add = ow.method([ow.number, ow.number], (a, b) => a + b)
+
+			add(1, 2)
+
+			// @ts-expect-error
+			add(1, 'foo')
+
+			// @ts-expect-error
+			add('foo', 2)
+
+			// @ts-expect-error
+			add(1, 2, 3)
+
+			// @ts-expect-error
+			add(1)
+
+			const plus = ow.method([ow.number, ow.number], 'plus', (a, b) => a + b)
+
+			plus(1, 2)
+
+			// @ts-expect-error
+			plus(1, 'foo')
+
+			// @ts-expect-error (argument `c` unexpected)
+			ow.method([ow.number, ow.number], (a, b, c) => a + b + c)
+
+			const add8 = ow.method([ow.number, ow.number, ow.number, ow.number, ow.number, ow.number, ow.number, ow.number], (a, b, c, d, e, f, g, h) => a + b + c + d + e + f + g + h)
+
+			add8(1, 2, 3, 4, 5, 6, 7, 8)
+
+			// @ts-expect-error
+			const add9 = ow.method([ow.number, ow.number, ow.number, ow.number, ow.number, ow.number, ow.number, ow.number, ow.number], (a, b, c, d, e, f, g, h, i) => a + b + c + d + e + f + g + h)
+		},
+
+		() => {
 			// To make sure all validators are mapped to the correct type, create a `Tests` type which requires that
 			// every property of `ow` has its type-mapping explicitly tested. If more properties are added this will
 			// fail until a type assertion is added below.
 
-			type AssertionProps = Exclude<keyof typeof ow, 'any' | 'isValid' | 'create' | 'optional'>;
+			type AssertionProps = Exclude<keyof typeof ow, 'any' | 'isValid' | 'create' | 'optional' | 'method'>;
 
 			type Tests = {
 				[K in AssertionProps]:

--- a/test/types.ts
+++ b/test/types.ts
@@ -90,42 +90,45 @@ function typeTests(value: unknown) {
 		},
 
 		() => {
-			const add = ow.method([ow.number, ow.number], (a, b) => a + b)
+			const add = ow.method([ow.number, ow.number], (a, b) => a + b);
 
-			add(1, 2)
-
-			// @ts-expect-error
-			add(1, 'foo')
+			add(1, 2);
 
 			// @ts-expect-error
-			add('foo', 2)
+			add(1, 'foo');
 
 			// @ts-expect-error
-			add(1, 2, 3)
+			add('foo', 2);
 
 			// @ts-expect-error
-			add(1)
+			add(1, 2, 3);
+
+			// @ts-expect-error
+			add(1);
 
 			const exclaim = ow.method([ow.string, ow.number.integer], 'exclaim', (text, enthusiasm) => {
-				expectTypeOf(text).toBeString()
-				expectTypeOf(enthusiasm).toBeNumber()
-				return text + '!'.repeat(enthusiasm)
-			})
+				expectTypeOf(text).toBeString();
+				expectTypeOf(enthusiasm).toBeNumber();
+				return text + '!'.repeat(enthusiasm);
+			});
 
-			exclaim('foo', 2)
+			exclaim('foo', 2);
 
 			// @ts-expect-error
-			exclaim('foo', 'bar')
+			exclaim('foo', 'bar');
 
 			// @ts-expect-error (argument `c` unexpected)
-			ow.method([ow.number, ow.number], (a, b, c) => a + b + c)
+			// eslint-disable-next-line @typescript-eslint/restrict-plus-operands
+			ow.method([ow.number, ow.number], (a, b, c) => a + b + c);
 
-			const add8 = ow.method([ow.number, ow.number, ow.number, ow.number, ow.number, ow.number, ow.number, ow.number], (a, b, c, d, e, f, g, h) => a + b + c + d + e + f + g + h)
+			// eslint-disable-next-line unicorn/prevent-abbreviations, max-params
+			const add8 = ow.method([ow.number, ow.number, ow.number, ow.number, ow.number, ow.number, ow.number, ow.number], (a, b, c, d, e, f, g, h) => a + b + c + d + e + f + g + h);
 
-			add8(1, 2, 3, 4, 5, 6, 7, 8)
+			add8(1, 2, 3, 4, 5, 6, 7, 8);
 
 			// @ts-expect-error
-			const add9 = ow.method([ow.number, ow.number, ow.number, ow.number, ow.number, ow.number, ow.number, ow.number, ow.number], (a, b, c, d, e, f, g, h, i) => a + b + c + d + e + f + g + h)
+			// eslint-disable-next-line @typescript-eslint/restrict-plus-operands, unicorn/prevent-abbreviations, max-params
+			const add9 = ow.method([ow.number, ow.number, ow.number, ow.number, ow.number, ow.number, ow.number, ow.number, ow.number], (a, b, c, d, e, f, g, h, i) => a + b + c + d + e + f + g + h);
 		},
 
 		() => {


### PR DESCRIPTION
This is something I've wished existed for a while. The problem being: I'd like to write a function with specific input types, which is going to be invoked from call-sites outside the project I'm working in (e.g., a library function, an http request/serverless function handler/some json file processor etc.).

But I'd also like to be able to call it internally - the simplest use case being from a unit test.

Example:

```ts
// calculator.ts
import ow from 'ow'

const add = ow.method([ow.number, ow.number], (a, b) => a + b)

const subtract = ow.method([ow.number, ow.number], (a, b) => a - b)

const multiply = ow.method([ow.number, ow.number], (a, b) => a * b)

const divide = ow.method([ow.number, ow.number.not.equal(0)], (a, b) => a / b)
```

Note that `a` and `b` are strongly typed (as numbers in the above example) in each function.

Previously the options aren't that great. You can either be safe by typing all inputs as `unknown`, which makes sure that the validation is done, but offers no help to callers or the function:

```ts
const add = (a: unknown, b: unknown) => {
  // good: the type system makes sure we remember to validate the inputs (albeit with some boilerplate)
  ow(a, ow.number)
  ow(b, ow.number)
  return a + b
}

// bad: the type system doesn't stop callers from sending bad inputs.
// This isn't a bug in the function, but it'll still lead to errors:
add('foo', { bar: true })
```

Or you can type them as `number`, which provides types to callers, but means that allows skipping the assertion at the type level, leading to errors at runtime if bad data is passed to the function:

```ts
// bad: type system has been told the inputs will definitely be a number. But what if the inputs come from an `any` type, or javascript?
const add = (a: number, b: number) => a + b

app.use((req, res) => {
  // undefined behaviour if someone sends a body like { "a": "foo", "b": { "bar": true } }?
  res.send({ sum: add(req.body.a, req.body.b) })
})
```

Or, you can write a separate type signature, leading to confusing/unnecessary boilerplate:

Instead of:

```ts
const add = ow.method([ow.number, ow.number], (a, b) => a + b)
```

you would have to do:

```ts
const add: (a: number, b: number) => number = (a: unknown, b: unknown) => {
  ow(a, ow.number)
  ow(b, ow.number)
  return a + b
}
```

Curious to hear any thoughts on the idea!

Update :I've since noticed similar functionality in [zod](https://github.com/colinhacks/zod/tree/v3#function-schemas).