### PR TITLE
Remove `any` in operators/not.ts

### DIFF
--- a/source/operators/not.ts
+++ b/source/operators/not.ts
@@ -1,5 +1,6 @@
 import randomId from '../utils/random-id';
 import {validatorSymbol} from '../predicates/predicate';
+import type {Predicate, Validator} from '../predicates/predicate';
 
 /**
 Operator which inverts the following validation.
@@ -8,10 +9,10 @@ Operator which inverts the following validation.
 
 @param predictate - Predicate to wrap inside the operator.
 */
-export const not = (predicate: any) => {
+export const not = (predicate: Predicate) => {
 	const originalAddValidator = predicate.addValidator;
 
-	predicate.addValidator = (validator: any) => {
+	predicate.addValidator = (validator: Validator<unknown>) => {
 		const {validator: fn, message, negatedMessage} = validator;
 		const placeholder = randomId();
 

--- a/source/operators/not.ts
+++ b/source/operators/not.ts
@@ -9,20 +9,20 @@ Operator which inverts the following validation.
 
 @param predictate - Predicate to wrap inside the operator.
 */
-export const not = (predicate: Predicate) => {
+export const not = (predicate: Predicate): Predicate => {
 	const originalAddValidator = predicate.addValidator;
 
-	predicate.addValidator = (validator: Validator<unknown>) => {
+	predicate.addValidator = (validator: Validator<unknown>): Predicate => {
 		const {validator: fn, message, negatedMessage} = validator;
 		const placeholder = randomId();
 
-		validator.message = (value: unknown, label: string) => (
+		validator.message = (value: unknown, label: string): string => (
 			negatedMessage ?
 				negatedMessage(value, label) :
 				message(value, placeholder).replace(/ to /, '$&not ').replace(placeholder, label)
 		);
 
-		validator.validator = (value: unknown) => !fn(value);
+		validator.validator = (value: unknown): unknown => !fn(value);
 
 		predicate[validatorSymbol].push(validator);
 

--- a/source/predicates/predicate.ts
+++ b/source/predicates/predicate.ts
@@ -160,8 +160,8 @@ export class Predicate<T = unknown> implements BasePredicate<T> {
 	/**
 	Invert the following validators.
 	*/
-	get not(): Predicate {
-		return not(this);
+	get not(): this {
+		return not(this) as this;
 	}
 
 	/**
@@ -237,7 +237,7 @@ export class Predicate<T = unknown> implements BasePredicate<T> {
 
 	@param validator - Validator to register.
 	*/
-	addValidator(validator: Validator<T>): Predicate {
+	addValidator(validator: Validator<T>): this {
 		this.context.validators.push(validator);
 		return this;
 	}

--- a/source/predicates/predicate.ts
+++ b/source/predicates/predicate.ts
@@ -237,7 +237,7 @@ export class Predicate<T = unknown> implements BasePredicate<T> {
 
 	@param validator - Validator to register.
 	*/
-	addValidator(validator: Validator<T>) {
+	addValidator(validator: Validator<T>): Predicate {
 		this.context.validators.push(validator);
 		return this;
 	}

--- a/source/predicates/predicate.ts
+++ b/source/predicates/predicate.ts
@@ -160,7 +160,7 @@ export class Predicate<T = unknown> implements BasePredicate<T> {
 	/**
 	Invert the following validators.
 	*/
-	get not(): this {
+	get not(): Predicate {
 		return not(this);
 	}
 
@@ -237,7 +237,7 @@ export class Predicate<T = unknown> implements BasePredicate<T> {
 
 	@param validator - Validator to register.
 	*/
-	protected addValidator(validator: Validator<T>) {
+	addValidator(validator: Validator<T>) {
 		this.context.validators.push(validator);
 		return this;
 	}


### PR DESCRIPTION
Remove `any` at `source/operators/not.ts`  by using [Type-Only Imports and Export](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-8.html#type-only-imports-and-export) and add annotation to the return value of functions.
(I'm trying https://github.com/sindresorhus/ow/pull/203#issuecomment-766324289.)