### PR TITLE
Fix `ow.object` to return `ArgumentError` when `null` or `undefined` is passed

### DIFF
--- a/source/predicates/object.ts
+++ b/source/predicates/object.ts
@@ -93,7 +93,7 @@ export class ObjectPredicate<T extends object = object> extends Predicate<T> {
 	instanceOf(instance: Function): this {
 		return this.addValidator({
 			message: (object: object, label: string) => {
-				let {name} = object.constructor;
+				let {name} = object?.constructor ?? {};
 
 				if (!name || name === 'Object') {
 					name = JSON.stringify(object);

--- a/test/object.ts
+++ b/test/object.ts
@@ -163,11 +163,11 @@ test('object.instanceOf', t => {
 
 	t.throws(() => {
 		ow(null, ow.object.instanceOf(Unicorn));
-	}, 'Expected object `null` to be of type `Unicorn`');
+	}, /Expected object `null` to be of type `Unicorn`/);
 
 	t.throws(() => {
 		ow(undefined, ow.object.instanceOf(Unicorn));
-	}, 'Expected object `undefined` to be of type `Unicorn`');
+	}, /Expected object `undefined` to be of type `Unicorn`/);
 });
 
 test('object.hasKeys', t => {
@@ -189,7 +189,7 @@ test('object.hasKeys', t => {
 
 	t.throws(() => {
 		ow({unicorn: '🦄'}, ow.object.hasKeys('unicorn', 'rainbow'));
-	}, 'Expected object `Unicorn` to have keys `["rainbow"]`');
+	}, 'Expected object to have keys `["rainbow"]`');
 
 	t.throws(() => {
 		ow({unicorn: {value: '🦄'}}, ow.object.hasKeys('unicorn.foo'));

--- a/test/object.ts
+++ b/test/object.ts
@@ -160,6 +160,14 @@ test('object.instanceOf', t => {
 	t.throws(() => {
 		ow({unicorn: '🦄'}, ow.object.instanceOf(Unicorn));
 	}, 'Expected object `{"unicorn":"🦄"}` to be of type `Unicorn`');
+
+	t.throws(() => {
+		ow(null, ow.object.instanceOf(Unicorn));
+	}, 'Expected object `null` to be of type `Unicorn`');
+
+	t.throws(() => {
+		ow(undefined, ow.object.instanceOf(Unicorn));
+	}, 'Expected object `undefined` to be of type `Unicorn`');
 });
 
 test('object.hasKeys', t => {


### PR DESCRIPTION
Fix: https://github.com/sindresorhus/ow/issues/201