### PR TITLE
Remove unnecessary stack reference for `ow.array.ofType`

### DIFF
--- a/source/index.ts
+++ b/source/index.ts
@@ -81,7 +81,7 @@ Object.defineProperties(ow, {
 	isValid: {
 		value: <T>(value: T, predicate: BasePredicate<T>): boolean => {
 			try {
-				ow(value, predicate);
+				test(value, '', predicate);
 				return true;
 			} catch {
 				return false;

--- a/source/predicates/array.ts
+++ b/source/predicates/array.ts
@@ -1,9 +1,9 @@
 import isEqual = require('lodash.isequal');
 import {BasePredicate} from './base-predicate';
 import {Predicate, PredicateOptions} from './predicate';
-import ow from '..';
 import {Shape} from './object';
 import {exact} from '../utils/match-shape';
+import ofType from '../utils/of-type';
 
 export class ArrayPredicate<T = unknown> extends Predicate<T[]> {
 	/**
@@ -142,23 +142,10 @@ export class ArrayPredicate<T = unknown> extends Predicate<T[]> {
 	```
 	*/
 	ofType<U extends T>(predicate: BasePredicate<U>): ArrayPredicate<U> {
-		let error: string;
-
 		// TODO [typescript@>=5] If higher-kinded types are supported natively by typescript, refactor `addValidator` to use them to avoid the usage of `any`. Otherwise, bump or remove this TODO.
 		return this.addValidator({
-			message: (_, label) => `(${label}) ${error}`,
-			validator: value => {
-				try {
-					for (const item of value) {
-						ow(item, predicate);
-					}
-
-					return true;
-				} catch (error_: unknown) {
-					error = (error_ as Error).message;
-					return false;
-				}
-			}
+			message: (_, label, error) => `(${label}) ${error}`,
+			validator: value => ofType(value, 'values', predicate)
 		}) as ArrayPredicate<any>;
 	}
 

--- a/test/array.ts
+++ b/test/array.ts
@@ -162,11 +162,19 @@ test('array.ofType', t => {
 
 	t.throws(() => {
 		ow(['foo', 'b'], ow.array.ofType(ow.string.minLength(3)));
-	}, '(array) Expected string to have a minimum length of `3`, got `b`');
+	}, '(array) Expected string values to have a minimum length of `3`, got `b`');
 
 	t.throws(() => {
 		ow(['foo', 'b'], 'foo', ow.array.ofType(ow.string.minLength(3)));
-	}, '(array `foo`) Expected string to have a minimum length of `3`, got `b`');
+	}, '(array `foo`) Expected string values to have a minimum length of `3`, got `b`');
+
+	t.throws(() => {
+		ow(['foo', 'bar'], 'foo', ow.array.ofType(ow.number));
+	}, '(array `foo`) Expected values to be of type `number` but received type `string`');
+
+	t.throws(() => {
+		ow([1, -1], 'foo', ow.array.ofType(ow.number.not.negative));
+	}, '(array `foo`) Expected number values to not be negative, got -1');
 });
 
 test('array.exactShape', t => {


### PR DESCRIPTION
- Remove unnecessary stack reference for `ow.array.ofType` and refine the error message.
- In the [last PR](https://github.com/sindresorhus/ow/pull/214), I missed the case for an array.