### PR TITLE
Fix input type on some methods and add `AssertingValidator`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ yarn.lock
 coverage
 dist
 docs
+.vscode

--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,3 @@ yarn.lock
 coverage
 dist
 docs
-.vscode

--- a/source/index.ts
+++ b/source/index.ts
@@ -75,7 +75,28 @@ export interface ReusableValidator<T> {
 	// eslint-disable-next-line @typescript-eslint/prefer-function-type
 	(value: unknown | T, label?: string): void;
 }
-export type AssertingValidator<T> = T extends ReusableValidator<infer R> ? (value: unknown, label?: string) => asserts value is R : never;
+
+/**
+Turns a ReusableValidator into one that narrows the type using assert.
+
+@example
+```
+const checkUsername = ow.create(ow.string.minLength(3));
+const checkUsername_: AssertingValidator<typeof checkUsername> = checkUsername;
+```
+
+@example
+```
+const predicate = ow.string.minLength(3);
+const checkUsername: AssertingValidator<typeof predicate> = ow.create(predicate);
+```
+*/
+export type AssertingValidator<T> =
+	T extends ReusableValidator<infer R>
+		? (value: unknown, label?: string) => asserts value is R
+		: T extends BasePredicate<infer R>
+			? (value: unknown, label?: string) => asserts value is R
+			: never;
 
 const ow = <T>(value: unknown, labelOrPredicate: unknown, predicate?: BasePredicate<T>): void => {
 	if (!isPredicate(labelOrPredicate) && typeof labelOrPredicate !== 'string') {

--- a/source/index.ts
+++ b/source/index.ts
@@ -77,7 +77,7 @@ export interface ReusableValidator<T> {
 }
 
 /**
-Turns a ReusableValidator into one that narrows the type using assert.
+Turn a `ReusableValidator` into one with a type assertion.
 
 @example
 ```

--- a/source/index.ts
+++ b/source/index.ts
@@ -52,7 +52,7 @@ export interface Ow extends Modifiers, Predicates {
 	@param value - Value to test.
 	@param predicate - Predicate to test against.
 	*/
-	isValid: <T>(value: T, predicate: BasePredicate<T>) => value is T;
+	isValid: <T>(value: unknown, predicate: BasePredicate<T>) => value is T;
 
 	/**
 	Create a reusable validator.
@@ -73,10 +73,11 @@ export interface ReusableValidator<T> {
 	@param label - Override the label which should be used in error messages.
 	*/
 	// eslint-disable-next-line @typescript-eslint/prefer-function-type
-	(value: T, label?: string): void;
+	(value: unknown | T, label?: string): void;
 }
+export type AssertingValidator<T> = T extends ReusableValidator<infer R> ? (value: unknown, label?: string) => asserts value is R : never;
 
-const ow = <T>(value: T, labelOrPredicate: unknown, predicate?: BasePredicate<T>): void => {
+const ow = <T>(value: unknown, labelOrPredicate: unknown, predicate?: BasePredicate<T>): void => {
 	if (!isPredicate(labelOrPredicate) && typeof labelOrPredicate !== 'string') {
 		throw new TypeError(`Expected second argument to be a predicate or a string, got \`${typeof labelOrPredicate}\``);
 	}
@@ -95,7 +96,7 @@ const ow = <T>(value: T, labelOrPredicate: unknown, predicate?: BasePredicate<T>
 
 Object.defineProperties(ow, {
 	isValid: {
-		value: <T>(value: T, predicate: BasePredicate<T>): boolean => {
+		value: <T>(value: unknown, predicate: BasePredicate<T>): boolean => {
 			try {
 				test(value, '', predicate);
 				return true;
@@ -105,7 +106,7 @@ Object.defineProperties(ow, {
 		}
 	},
 	create: {
-		value: <T>(labelOrPredicate: BasePredicate<T> | string | undefined, predicate?: BasePredicate<T>) => (value: T, label?: string): void => {
+		value: <T>(labelOrPredicate: BasePredicate<T> | string | undefined, predicate?: BasePredicate<T>) => (value: unknown, label?: string): asserts value is T => {
 			if (isPredicate(labelOrPredicate)) {
 				const stackFrames = callsites();
 

--- a/test/test.ts
+++ b/test/test.ts
@@ -292,6 +292,7 @@ test('isValid', t => {
 test('reusable validator', t => {
 	const checkUsername = ow.create(ow.string.minLength(3));
 	const checkUsername_: AssertingValidator<typeof checkUsername> = checkUsername;
+	const checkUsername__: AssertingValidator<typeof ow.string> = checkUsername;
 
 	const value = 'x';
 	const value_ = 'foo' as string | number;
@@ -307,6 +308,11 @@ test('reusable validator', t => {
 	t.notThrows(() => {
 		checkUsername_(value_);
 		((_: string): void => {})(value_); // The _ function should narrow the type. If it didn't, this would not compile
+	});
+
+	t.notThrows(() => {
+		checkUsername__(value_);
+		((_: string): void => {})(value_); // The __ function should narrow the type. If it didn't, this would not compile
 	});
 
 	t.throws(() => {


### PR DESCRIPTION
Fixes #222 

- Some functions incorrectly used `value: T` instead of `value: unknown` (want to `assert value is T`, not assume it)
- Added type to make `ReusableValidator` also `assert value is T`
- Convenience type to infer nested `BasePredicate` for `object.partialShape` (type-check that type and predicate are equal)

I am not fully sure about the last two points, suggestions welcome.