### PR TITLE
Add `string.nonBlank`

### DIFF
--- a/source/predicates/string.ts
+++ b/source/predicates/string.ts
@@ -132,7 +132,18 @@ export class StringPredicate extends Predicate<string> {
 	*/
 	get nonBlank(): this {
 		return this.addValidator({
-			message: (value, label) => `Expected ${label} to not be only whitespace, got \`${value}\``,
+			message: (value, label) => {
+				// Unicode's formal substitute characters can be barely legible and may not be easily recognized.
+				// Hence this alternative substitution scheme.
+				const madeVisible = value
+					.replace(/ /g, '·')
+					.replace(/\f/g, '\\f')
+					.replace(/\n/g, '\\n')
+					.replace(/\r/g, '\\r')
+					.replace(/\t/g, '\\t')
+					.replace(/\v/g, '\\v');
+				return `Expected ${label} to not be only whitespace, got \`${madeVisible}\``;
+			},
 			validator: value => value.trim() !== '',
 		});
 	}

--- a/source/predicates/string.ts
+++ b/source/predicates/string.ts
@@ -128,6 +128,16 @@ export class StringPredicate extends Predicate<string> {
 	}
 
 	/**
+	Test a string to contain at least 1 non-whitespace character.
+	*/
+	get nonBlank(): this {
+		return this.addValidator({
+			message: (value, label) => `Expected ${label} to not be only whitespace, got \`${value}\``,
+			validator: value => value.trim() !== '',
+		});
+	}
+
+	/**
 	Test a string to be not empty.
 	*/
 	get nonEmpty(): this {

--- a/test/string.ts
+++ b/test/string.ts
@@ -163,6 +163,16 @@ test('string.empty', t => {
 	}, {message: 'Expected string to be empty, got `foo`'});
 });
 
+test('string.nonBlank', t => {
+	t.notThrows(() => {
+		ow('foo', ow.string.nonBlank);
+	});
+
+	t.throws(() => {
+		ow(' \n\t', ow.string.nonBlank);
+	}, {message: 'Expected string to not be only whitespace, got ` \n\t`'});
+});
+
 test('string.nonEmpty', t => {
 	t.notThrows(() => {
 		ow('foo', ow.string.nonEmpty);

--- a/test/string.ts
+++ b/test/string.ts
@@ -169,8 +169,8 @@ test('string.nonBlank', t => {
 	});
 
 	t.throws(() => {
-		ow(' \n\t', ow.string.nonBlank);
-	}, {message: 'Expected string to not be only whitespace, got ` \n\t`'});
+		ow(' \n\t\f\v', ow.string.nonBlank);
+	}, {message: 'Expected string to not be only whitespace, got `·\\n\\t\\f\\v`'});
 });
 
 test('string.nonEmpty', t => {


### PR DESCRIPTION
fixes #226

Useful for all kinds of user/file/env sourced inputs that may contain strings of whitespace where a meaningful value is expected.