### PR TITLE
Fix `ow.number` message when `NaN` is encountered

### DIFF
--- a/source/predicates/predicate.ts
+++ b/source/predicates/predicate.ts
@@ -86,6 +86,7 @@ export class Predicate<T = unknown> implements BasePredicate<T> {
 				// We do not include type in this label as we do for other messages, because it would be redundant.
 				const label_ = label?.slice(this.type.length + 1);
 
+				// TODO: The NaN check can be removed when `@sindresorhus/is` is fixed: https://github.com/sindresorhus/ow/issues/231#issuecomment-1047100612
 				// eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
 				return `Expected ${label_ || 'argument'} to be of type \`${this.type}\` but received type \`${Number.isNaN(value) ? 'NaN' : is(value)}\``;
 			},

--- a/source/predicates/predicate.ts
+++ b/source/predicates/predicate.ts
@@ -87,7 +87,7 @@ export class Predicate<T = unknown> implements BasePredicate<T> {
 				const label_ = label?.slice(this.type.length + 1);
 
 				// eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
-				return `Expected ${label_ || 'argument'} to be of type \`${this.type}\` but received type \`${is(value)}\``;
+				return `Expected ${label_ || 'argument'} to be of type \`${this.type}\` but received type \`${Number.isNaN(value) ? 'NaN' : is(value)}\``;
 			},
 			// eslint-disable-next-line @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unsafe-call
 			validator: value => (is as any)[typeString](value),

--- a/test/number.ts
+++ b/test/number.ts
@@ -11,6 +11,10 @@ test('number', t => {
 	}, {message: 'Expected argument to be of type `number` but received type `string`'});
 
 	t.throws(() => {
+		ow(Number.NaN as any, ow.number);
+	}, {message: 'Expected argument to be of type `number` but received type `NaN`'});
+
+	t.throws(() => {
 		ow('12' as any, 'foo', ow.number);
 	}, {message: 'Expected `foo` to be of type `number` but received type `string`'});
 });


### PR DESCRIPTION
Partially handles #231 