### PR TITLE
Throw the correct error when second argument to `ow` is `undefined`

### DIFF
--- a/source/predicates/base-predicate.ts
+++ b/source/predicates/base-predicate.ts
@@ -8,7 +8,7 @@ export const testSymbol: unique symbol = Symbol('test');
 /**
 @hidden
 */
-export const isPredicate = (value: unknown): value is BasePredicate => Boolean((value as any)[testSymbol]);
+export const isPredicate = (value: unknown): value is BasePredicate => Boolean(value) && Boolean((value as any)[testSymbol]);
 
 /**
 @hidden

--- a/test/test.ts
+++ b/test/test.ts
@@ -517,6 +517,10 @@ test('ow without valid arguments', t => {
 	t.throws(() => {
 		ow(5, {} as any);
 	}, {message: 'Expected second argument to be a predicate or a string, got `object`'});
+
+	t.throws(() => {
+		ow(5, undefined);
+	}, {message: 'Expected second argument to be a predicate or a string, got `undefined`'});
 });
 
 // Skipped because require is not defined in esm


### PR DESCRIPTION
When calling `ow('value', undefined, ow.string)`, `ow` threw an unhelpful error:
```
TypeError: Cannot read property 'Symbol(test)' of undefined
      at isPredicate
...
```
because it tried to access a property on an `undefined` value.


This fixes it so that it throws the right error (as with other, non-undefined values):
```
Expected second argument to be a predicate or a string, got `undefined`
```