### PR TITLE
backwards compatibility with typescript module resolution

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
 		"url": "https://sindresorhus.com"
 	},
 	"type": "module",
+	"types": "dist/index.d.ts"
 	"exports": {
 		".": {
 			"types": "./dist/index.d.ts",


### PR DESCRIPTION
I'm using latest typescript version, and my project uses other libraries (i.e fastify/swagger plugin).
If I'm using `moduleResolution`: `node16` (or above) the `ow` module resolution works, but I'm getting types error from these other libraries.

By adding `types` to package.json I'm able to resolve modules both from other packages and this package as well