### PR TITLE
Replace `lodash.isequal` to `fast-equals`

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,12 +61,11 @@
 		"@sindresorhus/is": "^5.3.0",
 		"callsites": "^4.0.0",
 		"dot-prop": "^7.2.0",
-		"lodash.isequal": "^4.5.0",
+		"fast-equals": "^5.0.0",
 		"vali-date": "^1.0.0"
 	},
 	"devDependencies": {
 		"@sindresorhus/tsconfig": "^3.0.1",
-		"@types/lodash.isequal": "^4.5.6",
 		"@types/node": "^18.8.0",
 		"@types/vali-date": "^1.0.0",
 		"ava": "^4.3.3",

--- a/source/predicates/array.ts
+++ b/source/predicates/array.ts
@@ -1,4 +1,4 @@
-import isEqual from 'lodash.isequal';
+import {deepEqual} from 'fast-equals';
 import {exact} from '../utils/match-shape.js';
 import ofType from '../utils/of-type.js';
 import type {BasePredicate} from './base-predicate.js';
@@ -127,7 +127,7 @@ export class ArrayPredicate<T = unknown> extends Predicate<T[]> {
 	deepEqual(expected: readonly T[]): this {
 		return this.addValidator({
 			message: (value, label) => `Expected ${label} to be deeply equal to \`${JSON.stringify(expected)}\`, got \`${JSON.stringify(value)}\``,
-			validator: value => isEqual(value, expected),
+			validator: value => deepEqual(value, expected),
 		});
 	}
 

--- a/source/predicates/map.ts
+++ b/source/predicates/map.ts
@@ -1,4 +1,4 @@
-import isEqual from 'lodash.isequal';
+import {deepEqual} from 'fast-equals';
 import hasItems from '../utils/has-items.js';
 import ofType from '../utils/of-type.js';
 import {Predicate, type PredicateOptions} from './predicate.js';
@@ -152,7 +152,7 @@ export class MapPredicate<T1 = unknown, T2 = unknown> extends Predicate<Map<T1, 
 	deepEqual(expected: Map<T1, T2>): this {
 		return this.addValidator({
 			message: (map, label) => `Expected ${label} to be deeply equal to \`${JSON.stringify([...expected])}\`, got \`${JSON.stringify([...map])}\``,
-			validator: map => isEqual(map, expected),
+			validator: map => deepEqual(map, expected),
 		});
 	}
 }

--- a/source/predicates/object.ts
+++ b/source/predicates/object.ts
@@ -1,6 +1,6 @@
 import is from '@sindresorhus/is';
 import {hasProperty} from 'dot-prop';
-import isEqual from 'lodash.isequal';
+import {deepEqual} from 'fast-equals';
 import hasItems from '../utils/has-items.js';
 import ofType from '../utils/of-type.js';
 import ofTypeDeep from '../utils/of-type-deep.js';
@@ -78,7 +78,7 @@ export class ObjectPredicate<T extends object = object> extends Predicate<T> {
 	deepEqual(expected: object): this {
 		return this.addValidator({
 			message: (object, label) => `Expected ${label} to be deeply equal to \`${JSON.stringify(expected)}\`, got \`${JSON.stringify(object)}\``,
-			validator: object => isEqual(object, expected),
+			validator: object => deepEqual(object, expected),
 		});
 	}
 

--- a/source/predicates/set.ts
+++ b/source/predicates/set.ts
@@ -1,4 +1,4 @@
-import isEqual from 'lodash.isequal';
+import {deepEqual} from 'fast-equals';
 import hasItems from '../utils/has-items.js';
 import ofType from '../utils/of-type.js';
 import {Predicate, type PredicateOptions} from './predicate.js';
@@ -113,7 +113,7 @@ export class SetPredicate<T = any> extends Predicate<Set<T>> {
 	deepEqual(expected: Set<T>): this {
 		return this.addValidator({
 			message: (set, label) => `Expected ${label} to be deeply equal to \`${JSON.stringify([...expected])}\`, got \`${JSON.stringify([...set])}\``,
-			validator: set => isEqual(set, expected),
+			validator: set => deepEqual(set, expected),
 		});
 	}
 }


### PR DESCRIPTION
Suggestion to replace `lodash.isequal` to well-maintained faster implementation.